### PR TITLE
Add options for image pasting (WMF format)

### DIFF
--- a/WikidPad.xrc
+++ b/WikidPad.xrc
@@ -1368,7 +1368,23 @@
       </object>
       <object class="sizeritem">
         <object class="wxCheckBox" name="cbEditorImagePasteAskOnEachPaste">
-          <label>Ask settings on each paste</label>
+          <label>Ask settings on each image paste</label>
+        </object>
+        <option>0</option>
+        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>
+        <border>5</border>
+      </object>
+      <object class="sizeritem">
+        <object class="wxCheckBox" name="cbEditorImagePasteAlwaysGetTextOnly">
+          <label>Always paste text instead of image</label>
+        </object>
+        <option>0</option>
+        <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>
+        <border>5</border>
+      </object>
+      <object class="sizeritem">
+        <object class="wxCheckBox" name="cbEditorImagePasteGetTextOnlyFromWmf">
+          <label>WMF data: Paste text instead of image</label>
         </object>
         <option>0</option>
         <flag>wxALL|wxEXPAND|wxALIGN_CENTRE_VERTICAL</flag>

--- a/lib/pwiki/Configuration.py
+++ b/lib/pwiki/Configuration.py
@@ -38,17 +38,17 @@ def _setValue(section, option, value, config):
 
     if type(option) is unicode:
         option = utf8Enc(option)[0]
-        
+
     if type(value) is str:
         value = utf8Enc(mbcsDec(value)[0])[0]
     elif type(value) is unicode:
         value = utf8Enc(value)[0]
     else:
         value = utf8Enc(unicode(value))[0]
-        
+
     if not config.has_section(section):
-        config.add_section(section) 
-        
+        config.add_section(section)
+
     config.set(section, option, value)
 
 
@@ -79,7 +79,7 @@ class _AbstractConfiguration:
         result = self.get(section, option)
         if result is None:
             return default
-        
+
         try:
             return float(result)
         except ValueError:
@@ -91,7 +91,7 @@ class _AbstractConfiguration:
         result = self.get(section, option)
         if result is None:
             return default
-        
+
         return strToBool(result, False)
 
     @staticmethod
@@ -115,12 +115,12 @@ class SingleConfiguration(_AbstractConfiguration, MiscEventSourceMixin):
                 (only stored here, but processed by CombinedConfiguration)
         """
         MiscEventSourceMixin.__init__(self)
-        
+
         self.configParserObject = None
         self.configPath = None
-        
+
         self.configDefaults = configdef
-        
+
         if fallthroughDict is None:
             self.fallthroughDict = {}
         else:
@@ -138,7 +138,7 @@ class SingleConfiguration(_AbstractConfiguration, MiscEventSourceMixin):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         result = None
 
         if self.isOptionAllowed(section, option):
@@ -174,21 +174,21 @@ class SingleConfiguration(_AbstractConfiguration, MiscEventSourceMixin):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         if self.isOptionAllowed(section, option):
             return self.configDefaults[(section, option)]
         else:
             raise UnknownOptionException, _(u"Unknown option %s:%s") % (section, option)
-        
-        
-        
-        
+
+
+
+
     def setWriteAccessDenied(self, flag):
         self.writeAccessDenied = flag
-        
+
     def getWriteAccessDenied(self):
         return self.writeAccessDenied
-        
+
     def isReadOnlyEffect(self):
         return self.writeAccessDenied
 
@@ -215,7 +215,7 @@ class SingleConfiguration(_AbstractConfiguration, MiscEventSourceMixin):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         if self.isOptionAllowed(section, option):
             _setValue(section, option, value, self.configParserObject)
         else:
@@ -252,7 +252,7 @@ class SingleConfiguration(_AbstractConfiguration, MiscEventSourceMixin):
     def createEmptyConfig(self, fn):
         config = ConfigParser.ConfigParser()
         self.setConfigParserObject(config, fn)
-        
+
     def getFallthroughDict(self):
         return self.fallthroughDict
 
@@ -291,7 +291,7 @@ class CombinedConfiguration(_AbstractConfiguration):
     Manages global and wiki specific configuration options.
     Mainly wraps two SingleConfiguration instances
     """
-    
+
     def __init__(self, globalconfig, wikiconfig):
         """
         globalconfig -- SingleConfiguration object for global settings
@@ -310,12 +310,12 @@ class CombinedConfiguration(_AbstractConfiguration):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         result = None
-        
+
         checkWiki = True
         checkGlobal = True
-        
+
         if option.startswith("option/wiki/"):
             option = option[12:]
             checkGlobal = False
@@ -331,7 +331,7 @@ class CombinedConfiguration(_AbstractConfiguration):
                 if not ftDict.has_key((section, option)) or \
                         ftDict[(section, option)] != result:
                     checkGlobal = False
-                
+
             # TODO more elegantly
             elif WIKIDEFAULTS.has_key((section, option)):
                 result = default
@@ -350,7 +350,7 @@ class CombinedConfiguration(_AbstractConfiguration):
 
         return result
 
-        
+
     def getDefault(self, section, option):
         """
         Return the default configuration value as string/unicode
@@ -360,12 +360,12 @@ class CombinedConfiguration(_AbstractConfiguration):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         result = None
-        
+
         checkWiki = True
         checkGlobal = True
-        
+
         if option.startswith("option/wiki/"):
             option = option[12:]
             checkGlobal = False
@@ -404,10 +404,10 @@ class CombinedConfiguration(_AbstractConfiguration):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         checkWiki = True
         checkGlobal = True
-        
+
         if option.startswith("option/wiki/"):
             option = option[12:]
             checkGlobal = False
@@ -430,7 +430,7 @@ class CombinedConfiguration(_AbstractConfiguration):
 
         if type(option) is unicode:
             option = utf8Enc(option)[0]
-            
+
         if option.startswith("option/wiki/"):
             option = option[12:]
             self.wikiConfig.set(section, option, value)
@@ -570,10 +570,10 @@ GLOBALDEFAULTS = {
             # 0:Left, 1:Right, 2:Above, 3:Below
     ("main", "viewsTree_position"): u"0",  # Mode how to show the "Views" tree relative to main tree,
             # 0: Not at all, 1:Above, 2:Below, 3:Left, 4:Right
-            
+
         # Actual layout data processed by PersonalWikiFrame.changeLayoutByCf()
         # which in turn calls WindowLayout.WindowSashLayouter.realizeNewLayoutByCf()
-        
+
         # The value is not set directly but generated by
         # WindowLayout.calculateMainWindowLayoutCfString() each time configuration
         # changes by using some of the other layout settings in configuration.
@@ -604,7 +604,7 @@ GLOBALDEFAULTS = {
             # wiki
     ("main", "hotKey_showHide_byApp_isActive"): u"True", # Separate switch to deactivate hotkey
             # without deleting the hotkey setting itself
-            
+
     ("main", "wikiOpenNew_defaultDir"): u"",   # Default directory to show when opening
             # or creating a wiki. If entry is empty, a built-in default is used.
 
@@ -615,7 +615,7 @@ GLOBALDEFAULTS = {
     ("main", "auto_save"): "True",  # Boolean field, if auto save should be active
     ("main", "auto_save_delay_key_pressed"): "5",  # Seconds to wait after last key pressed and ...
     ("main", "auto_save_delay_dirty"): "60",  # secs. to wait after page became dirty before auto save
-     
+
     ("main", "hideundefined"): "False", # hide undefined wikiwords in tree
     ("main", "tree_auto_follow"): "True", # The tree selection follows when opening a wiki word
     ("main", "tree_update_after_save"): "True", # The tree is updated after a save
@@ -708,8 +708,8 @@ GLOBALDEFAULTS = {
     ("main", "editor_imagePaste_askOnEachPaste"): "True",  # When pasting image, ask each time for settings?
     ("main", "editor_filePaste_prefix"): "",  # When dropping files into editor, how to prefix, join(middle) and suffix them?
     ("main", "editor_filePaste_middle"): "\\x20",  # These three values are escaped with StringOps.escapeForIni to preserve spaces
-    ("main", "editor_filePaste_suffix"): "",  
-    ("main", "editor_filePaste_bracketedUrl"): "True", # Should the URL be inserted in brackets (and with 
+    ("main", "editor_filePaste_suffix"): "",
+    ("main", "editor_filePaste_bracketedUrl"): "True", # Should the URL be inserted in brackets (and with
             # spaces in it preserved unquoted)?
 
     ("main", "userEvent_event/paste/editor/files"): u"action/editor/this/paste/files/insert/url/ask",  # How to react on pasting files into editor?
@@ -752,7 +752,7 @@ GLOBALDEFAULTS = {
 
     ("main", "mouse_scrollUnderPointer"): "False", # Windows only, experimental, incomplete: Scroll window under pointer instead
             # of focused window
-            
+
     ("main", "mouse_reverseWheelZoom"): "False", # Normally (since 2.3beta13) upward is zoom in, downward is zoom out.
             # If this settings is true this is reversed for editor and internal HTML-preview (other previews not supported)
 
@@ -777,11 +777,11 @@ GLOBALDEFAULTS = {
     ("main", "timeView_position"): "0",  # Mode where to place the time view window,
             # 0: Hidden, 1:Left, 2:Right, 3:Above, 4:Below
     ("main", "timeView_dateFormat"): u"%Y %m %d",  # Time format to show and enter dates in the time view,
-            # especially in the timeline    
+            # especially in the timeline
     ("main", "timeView_autohide"): "False", # Automatically hide time view after something was selected in it.
     ("main", "timeView_showWordListOnHovering"): u"True", # If True the wordlist of a date is shown when hovering
             # over the entry
-    ("main", "timeView_showWordListOnSelect"): u"False", # If True the wordlist of a date is shown when 
+    ("main", "timeView_showWordListOnSelect"): u"False", # If True the wordlist of a date is shown when
             # entry is selected
     ("main", "timeView_lastSelectedTab"): u"modified", # Which tab was selected last when closing WikidPad?
             # "modified": Modified time, "version": Versioning tab
@@ -835,7 +835,7 @@ GLOBALDEFAULTS = {
     ("main", "windowmode"): "0",
     ("main", "frame_stayOnTop"): "False",  # Should frame stay on top of all other windows?
     ("main", "showontray"): "0",
-    ("main", "minimize_on_closeButton"): "False", # Minimize if the close button ("X") is pressed  
+    ("main", "minimize_on_closeButton"): "False", # Minimize if the close button ("X") is pressed
     ("main", "mainTabs_switchMruOrder"): "True", # Switch between tabs in most-recently used order
     ("main", "startup_splashScreen_show"): "True", # Show splash screen on startup
     ("main", "openWordDialog_askForCreateWhenNonexistingWord"): "True", # Ask if to create
@@ -861,7 +861,7 @@ GLOBALDEFAULTS = {
             # are stored relative to application dir.
     ("main", "openWikiWordDialog_sortOrder"): "0", # Sort order in "Open Wiki Word" dialog
             # 0:Alphabetically; 1:By last visit, newest first; 2:By last visit, oldest first; 3:Alphabetically reverse
-    
+
     ("main", "collation_order"): "Default", # Set collation order, Default: system default order, C: ASCII byte value
     ("main", "collation_uppercaseFirst"): "False" # Sort uppercase first (ABCabc) or normal inorder (AaBbCc)
 
@@ -928,7 +928,7 @@ WIKIDEFAULTS = {
     ("main", "db_pagefile_suffix"): u".wiki",  # Suffix of the page files for "Original ..."
                                              # db types
     ("main", "export_default_dir"): u"",  # Default directory for exports, u"" means fill in last active directory
-    
+
     ("main", "wiki_readOnly"): u"False",   # Should wiki be read only?
 
     ("main", "log_window_autoshow"): u"Gray", # Automatically show log window if messages added? "Gray" means to look at
@@ -954,7 +954,7 @@ WIKIDEFAULTS = {
 
     # For file storage (esp. identity check)
     ("main", "fileStorage_identity_modDateMustMatch"): u"False",  # Modification date must match for file to be identical
-    ("main", "fileStorage_identity_filenameMustMatch"): u"False",  # Filename must match for file 
+    ("main", "fileStorage_identity_filenameMustMatch"): u"False",  # Filename must match for file
     ("main", "fileStorage_identity_modDateIsEnough"): u"False",
             # Same modification date is enough to claim files identical (no content compare)
 
@@ -994,7 +994,7 @@ WIKIFALLTHROUGH ={
 
 
 
-# Maps configuration setting "mouse_middleButton_withoutCtrl" number to a 
+# Maps configuration setting "mouse_middleButton_withoutCtrl" number to a
 # tabMode number for WikiTxtCtrl._activateLink or WikiHtmlView._activateLink
 MIDDLE_MOUSE_CONFIG_TO_TABMODE = {
                                     0: 2, # New tab in foreground
@@ -1008,12 +1008,12 @@ MIDDLE_MOUSE_CONFIG_TO_TABMODE = {
 # def createCombinedConfiguration():
 #     return CombinedConfiguration(createGlobalConfiguration(),
 #             createWikiConfiguration())
-#             
-# 
+#
+#
 # def createWikiConfiguration():
 #     return SingleConfiguration(WIKIDEFAULTS)
-# 
-# 
+#
+#
 # def createGlobalConfiguration():
 #     return SingleConfiguration(GLOBALDEFAULTS)
 

--- a/lib/pwiki/Configuration.py
+++ b/lib/pwiki/Configuration.py
@@ -706,6 +706,8 @@ GLOBALDEFAULTS = {
     ("main", "editor_imagePaste_quality"): "75",  # Which quality should the (JPEG-)image have?
             # 0 zero means very bad, 100 means very good
     ("main", "editor_imagePaste_askOnEachPaste"): "True",  # When pasting image, ask each time for settings?
+    ("main", "editor_imagePaste_alwaysGetTextOnly"): "False",  # When about to paste an image, paste text instead
+    ("main", "editor_imagePaste_getTextOnlyFromWmf"): "False",  # When about to paste WMF image, paste text instead (if included in data)
     ("main", "editor_filePaste_prefix"): "",  # When dropping files into editor, how to prefix, join(middle) and suffix them?
     ("main", "editor_filePaste_middle"): "\\x20",  # These three values are escaped with StringOps.escapeForIni to preserve spaces
     ("main", "editor_filePaste_suffix"): "",

--- a/lib/pwiki/OptionsDialog.py
+++ b/lib/pwiki/OptionsDialog.py
@@ -498,6 +498,8 @@ class OptionsDialog(wx.Dialog):
             ("editor_imagePaste_fileType", "chEditorImagePasteFileType", "seli"),
             ("editor_imagePaste_quality", "tfEditorImagePasteQuality", "i0+"),
             ("editor_imagePaste_askOnEachPaste", "cbEditorImagePasteAskOnEachPaste", "b"),
+            ("editor_imagePaste_alwaysGetTextOnly", "cbEditorImagePasteAlwaysGetTextOnly", "b"),
+            ("editor_imagePaste_getTextOnlyFromWmf", "cbEditorImagePasteGetTextOnlyFromWmf", "b"),
             ("editor_filePaste_prefix", "tfEditorFilePastePrefix", "tes"),
             ("editor_filePaste_middle", "tfEditorFilePasteMiddle", "tes"),
             ("editor_filePaste_suffix", "tfEditorFilePasteSuffix", "tes"),

--- a/lib/pwiki/OptionsDialog.py
+++ b/lib/pwiki/OptionsDialog.py
@@ -42,9 +42,9 @@ class ResourceOptionsPanel(DefaultOptionsPanel):
         self.PostCreate(p)
 #         self.optionsDlg = optionsDlg
         res = wx.xrc.XmlResource.Get()
-        
+
         res.LoadOnPanel(self, parent, resName)
-        
+
     def setVisible(self, vis):
         return True
 
@@ -64,11 +64,11 @@ class PluginOptionsPanel(DefaultOptionsPanel):
         self.optionToControl = []
         self.mainControl = optionsDlg.getMainControl()
 
-    
+
     def addOptionEntry(self, opt, ctl, typ, *params):
         self.optionToControl.append((opt, ctl, typ) + params)
-    
-    
+
+
     def transferOptionsToDialog(self, config=None):
         # List of tuples (<configuration file entry>, <gui control name>, <type>)
         # Supported types:
@@ -85,14 +85,14 @@ class PluginOptionsPanel(DefaultOptionsPanel):
         #     spin: Numeric SpinCtrl
         #
         #     guilang: special choice for GUI language
-    
+
         # ttdf and color0 entries have a 4th item with the name
         #     of the "..." button to call a dialog to set.
         # selt entries have a list with the internal config names (unicode) of the
         #     possible choices as 4th item.
 
         # Transfer options to dialog
-        
+
         if config is None:
             config = self.mainControl.getConfig()
 
@@ -122,7 +122,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
 #                         config.getboolean("main", o))
         elif t in ("t", "tre", "ttdf", "i0+", "f0+", "color0"):  # text field or regular expression field
             ctl.SetValue( uniToGui(config.get("main", o)) )
-        elif t == "tes":  # Text escaped 
+        elif t == "tes":  # Text escaped
             ctl.SetValue( unescapeForIni(uniToGui(config.get("main", o))) )
         elif t == "seli":   # Selection -> transfer index
             ctl.SetSelection(config.getint("main", o))
@@ -139,8 +139,8 @@ class PluginOptionsPanel(DefaultOptionsPanel):
             ctl.Append(_(u"Default"))
             for ls, lt in Localization.getLangList():
                 ctl.Append(lt)
-            
-            # Then select previous setting                
+
+            # Then select previous setting
             optValue = config.get("main", o)
             ctl.SetSelection(Localization.findLangListIndex(optValue) + 1)
 
@@ -162,7 +162,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
         Called when "OK" is pressed in dialog. The plugin should check here if
         all input values are valid. If not, it should return False, then the
         Options dialog automatically shows this panel.
-        
+
         There should be a visual indication about what is wrong (e.g. red
         background in text field). Be sure to reset the visual indication
         if field is valid again.
@@ -173,7 +173,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
         for oct in self.optionToControl:
             if not self.checkSingleOptionOk(oct):
                 fieldsValid = False
-        
+
         return fieldsValid
 
 
@@ -214,7 +214,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
             # HTML Color field or empty field
             val = guiToUni(ctl.GetValue())
             rgb = colorDescToRgbTuple(val)
-            
+
             if val != "" and rgb is None:
                 ctl.SetBackgroundColour(wx.RED)
                 fieldsValid = False
@@ -275,7 +275,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
                 config.set("main", o,
                         oct[3][ctl.GetSelection()])
             except IndexError:
-                config.set("main", o, 
+                config.set("main", o,
                         guiToUni(ctl.GetStringSelection()))
         elif t == "spin":   # Numeric SpinCtrl -> transfer number
             config.set(
@@ -297,7 +297,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
         oct = self.idToOptionEntryMap[evt.GetId()]
         o, ctl, t = oct[:3]
         params = oct[3:]
-        
+
         if t == "color0":
             self.selectColor(ctl)
         elif t == "ttdf":   # Date/time format
@@ -325,7 +325,7 @@ class PluginOptionsPanel(DefaultOptionsPanel):
             dlg.Destroy()
 
     def selectDateTimeFormat(self, tfield):
-        dlg = DateformatDialog(self, -1, self.mainControl, 
+        dlg = DateformatDialog(self, -1, self.mainControl,
                 deffmt=tfield.GetValue())
         try:
             if dlg.ShowModal() == wx.ID_OK:
@@ -366,7 +366,7 @@ class OptionsDialog(wx.Dialog):
     #     of the "..." button to call for a dialog to set.
     # selt entries have a list with the internal config names (unicode) of the
     #     possible choices as 4th item.
-    
+
     _lastShownPanelName = None
 
 
@@ -539,7 +539,7 @@ class OptionsDialog(wx.Dialog):
                     u"action/presenter/this/subcontrol/textedit",
                     u"action/presenter/new/foreground/end/page/this/subcontrol/textedit"
                     ]),
-                
+
             ("userEvent_mouse/middleclick/pagetab", "chMouseMdlClickPageTab", "selt",
                     [
                     u"action/none",
@@ -656,7 +656,7 @@ class OptionsDialog(wx.Dialog):
             ("wikiPageFiles_maxNameLength", "tfWikiPageFilesMaxNameLength", "i0+"),
             ("wikiPageFiles_gracefulOutsideAddAndRemove",
                     "cbWikiPageFilesGracefulOutsideAddAndRemove", "b"),
-            
+
 
             ("wiki_icon", "tfWikiIcon", "t"),
             ("hotKey_showHide_byWiki", "tfHotKeyShowHideByWiki", "t"),
@@ -707,14 +707,14 @@ class OptionsDialog(wx.Dialog):
             ("clipboardCatcher_soundFile", "tfClipCatchSoundFile", "t")
     )
 
-    # Non-Windows specific options    
+    # Non-Windows specific options
     OPTION_TO_CONTROL_NON_WINDOWS_ONLY = (
             ("fileLauncher_path", "tfFileLauncherPath", "t"),
     )
 
 
     DEFAULT_PANEL_LIST = (
-            ("OptionsPageApplication", N_(u"Application")),    
+            ("OptionsPageApplication", N_(u"Application")),
             ("OptionsPageUserInterface", 2 * u" " + N_(u"User interface")),
             ("OptionsPageSecurity", 2 * u" " + N_(u"Security")),
             ("OptionsPageTree", 2 * u" " + N_(u"Tree")),
@@ -726,9 +726,9 @@ class OptionsDialog(wx.Dialog):
             ("OptionsPageFileLauncher", 2 * u" " + N_(u"File Launcher")),
             ("OptionsPageMouse", 2 * u" " + N_(u"Mouse")),
             ("OptionsPageChronView", 2 * u" " + N_(u"Chron. view")),
-            ("OptionsPageSearching", 2 * u" " + N_(u"Searching")),  
-            ("OptionsPageNewWikiDefaults", 2 * u" " + N_(u"New wiki defaults")),  
-            ("OptionsPageAdvanced", 2 * u" " + N_(u"Advanced")),  
+            ("OptionsPageSearching", 2 * u" " + N_(u"Searching")),
+            ("OptionsPageNewWikiDefaults", 2 * u" " + N_(u"New wiki defaults")),
+            ("OptionsPageAdvanced", 2 * u" " + N_(u"Advanced")),
             ("OptionsPageAdvTiming", 4 * u" " + N_(u"Timing")),
             ("OptionsPageAutosave", 4 * u" " + N_(u"Autosave")),
             ("??switch mark/current wiki/begin", u""),
@@ -755,7 +755,7 @@ class OptionsDialog(wx.Dialog):
         res.LoadOnDialog(self, self.pWiki, "OptionsDialog")
 
         self.combinedOptionToControl = self.OPTION_TO_CONTROL_GLOBAL
-        
+
         if self.pWiki.isWikiLoaded():
             self.combinedOptionToControl += self.OPTION_TO_CONTROL_WIKI
 
@@ -776,7 +776,7 @@ class OptionsDialog(wx.Dialog):
             # Remove wiki-bound setting pages
             try:
                 del self.combinedPanelList[self.combinedPanelList.index(
-                        ("??switch mark/current wiki/begin", u"")) : 
+                        ("??switch mark/current wiki/begin", u"")) :
                         self.combinedPanelList.index(
                         ("??switch mark/current wiki/end", u""))]
             except ValueError:
@@ -785,7 +785,7 @@ class OptionsDialog(wx.Dialog):
 
         # Rewrite panel list depending on OS and environment
         newPL = []
-        
+
         for e in self.combinedPanelList:
             if isinstance(e[0], basestring):
                 if e[0] == "OptionsPageFileLauncher" and SystemInfo.isWindows():
@@ -807,7 +807,7 @@ class OptionsDialog(wx.Dialog):
 
 #         if SystemInfo.isWindows():
 #             self.combinedOptionToControl += self.OPTION_TO_CONTROL_CLIPBOARD_CATCHER
-# 
+#
 #             newPL = []
 #             for e in self.combinedPanelList:
 #                 if isinstance(e[0], basestring):
@@ -816,13 +816,13 @@ class OptionsDialog(wx.Dialog):
 #                     if e[0].startswith("??"):
 #                         # Entry is only a mark for insert operations so skip it
 #                         continue
-# 
+#
 #                 newPL.append(e)
-# 
+#
 #             self.combinedPanelList = newPL
 #         else:
 #             self.combinedOptionToControl += self.OPTION_TO_CONTROL_NON_WINDOWS_ONLY
-# 
+#
 #             newPL = []
 #             for i, e in enumerate(self.combinedPanelList):
 #                 if isinstance(e[0], basestring):
@@ -831,9 +831,9 @@ class OptionsDialog(wx.Dialog):
 #                     if e[0].startswith("??"):
 #                         # Entry is only a mark for insert operations so skip it
 #                         continue
-# 
+#
 #                 newPL.append(e)
-# 
+#
 #             self.combinedPanelList = newPL
 
         self.ctrls = XrcControls(self)
@@ -845,7 +845,7 @@ class OptionsDialog(wx.Dialog):
 
 
         mainsizer = LayerSizer()  # wx.BoxSizer(wx.VERTICAL)
-        
+
         for pn, pt in self.combinedPanelList:
             indPt, textPt = splitIndent(pt)
             pt = indPt + _(textPt)
@@ -854,7 +854,7 @@ class OptionsDialog(wx.Dialog):
                     panel = ResourceOptionsPanel(self.ctrls.panelPages, pn)
                 else:
                     if self.emptyPanel is None:
-                        # Necessary to avoid a crash        
+                        # Necessary to avoid a crash
                         self.emptyPanel = DefaultOptionsPanel(self.ctrls.panelPages)
                     panel = self.emptyPanel
             else:
@@ -864,8 +864,8 @@ class OptionsDialog(wx.Dialog):
             self.panelList.append(panel)
             self.ctrls.lbPages.Append(pt)
             mainsizer.Add(panel)
-        
-        
+
+
         self.ctrls.panelPages.SetSizer(mainsizer)
         self.ctrls.panelPages.SetMinSize(mainsizer.GetMinSize())
 
@@ -882,7 +882,7 @@ class OptionsDialog(wx.Dialog):
             self.ctrls.chHtmlPreviewRenderer.optionsDialog_clientData.append(1)
             self.ctrls.chHtmlPreviewRenderer.Append(_(u"Mozilla"))
             self.ctrls.chHtmlPreviewRenderer.optionsDialog_clientData.append(2)
-        
+
         if WikiHtmlView.WikiHtmlViewWK is not None:
             self.ctrls.chHtmlPreviewRenderer.Append(_(u"Webkit"))
             self.ctrls.chHtmlPreviewRenderer.optionsDialog_clientData.append(3)
@@ -919,7 +919,7 @@ class OptionsDialog(wx.Dialog):
                     "color0"):  # text field or regular expression field
                 self.ctrls[c].SetValue(
                         uniToGui(self.pWiki.getConfig().get("main", o)) )
-            elif t == "tes":  # Text escaped 
+            elif t == "tes":  # Text escaped
                 self.ctrls[c].SetValue(
                         unescapeForIni(uniToGui(self.pWiki.getConfig().get(
                         "main", o))) )
@@ -947,8 +947,8 @@ class OptionsDialog(wx.Dialog):
                 self.ctrls[c].Append(_(u"Default"))
                 for ls, lt in Localization.getLangList():
                     self.ctrls[c].Append(lt)
-                
-                # Then select previous setting                
+
+                # Then select previous setting
                 optValue = self.pWiki.getConfig().get("main", o)
                 self.ctrls[c].SetSelection(
                         Localization.findLangListIndex(optValue) + 1)
@@ -961,9 +961,9 @@ class OptionsDialog(wx.Dialog):
                     self.ctrls[c].Append(ld[1])
                     if ld[0] == optValue:
                         sel = i
-                
+
                 if sel > -1:
-                    # Then select previous setting                
+                    # Then select previous setting
                     self.ctrls[c].SetSelection(sel)
 
             # Register events for "..." buttons
@@ -983,12 +983,12 @@ class OptionsDialog(wx.Dialog):
                 "new_window_on_follow_wiki_url") != 0)
 
         wikiDocument = self.pWiki.getWikiDocument()
-        if wikiDocument is not None:        
+        if wikiDocument is not None:
             self.ctrls.cbWikiReadOnly.SetValue(
                     wikiDocument.getWriteAccessDeniedByConfig())
 
             fppCap = wikiDocument.getWikiData().checkCapability("filePerPage")
-            
+
             self.ctrls.cbWikiPageFilesAsciiOnly.Enable(fppCap is not None)
             self.ctrls.tfWikiPageFilesMaxNameLength.Enable(fppCap is not None)
             self.ctrls.cbWikiPageFilesGracefulOutsideAddAndRemove.Enable(
@@ -1008,7 +1008,7 @@ class OptionsDialog(wx.Dialog):
         for panel in self.panelList:
             panel.Show(False)
             panel.Enable(False)
-        
+
         if startPanelName is None:
             startPanelName = OptionsDialog._lastShownPanelName
 
@@ -1048,10 +1048,10 @@ class OptionsDialog(wx.Dialog):
                 self.OnUpdateUiAfterChange)
         wx.EVT_CHOICE(self, GUI_ID.chEditorImagePasteFileType,
                 self.OnUpdateUiAfterChange)
-                
+
         wx.EVT_CHOICE(self, GUI_ID.chHtmlPreviewRenderer,
                 self.OnUpdateUiAfterChange)
-        
+
         wx.EVT_CHECKBOX(self, GUI_ID.cbWwSearchCountOccurrences,
                 self.OnUpdateUiAfterChange)
 
@@ -1140,7 +1140,7 @@ class OptionsDialog(wx.Dialog):
                 # HTML Color field or empty field
                 val = guiToUni(self.ctrls[c].GetValue())
                 rgb = colorDescToRgbTuple(val)
-                
+
                 if val != "" and rgb is None:
                     self.ctrls[c].SetBackgroundColour(wx.RED)
                     fieldsValid = False
@@ -1162,7 +1162,7 @@ class OptionsDialog(wx.Dialog):
         if not fieldsValid:
             self.Refresh()
             return
-            
+
         # Check each panel
         for i, panel in enumerate(self.panelList):
             if not panel.checkOk():
@@ -1171,7 +1171,7 @@ class OptionsDialog(wx.Dialog):
                 self._refreshForPage()
                 return
 
-        
+
         # Options with special treatment (before standard handling)
         wikiDocument = self.pWiki.getWikiDocument()
 
@@ -1211,7 +1211,7 @@ class OptionsDialog(wx.Dialog):
                 try:
                     config.set("main", o, oct[3][self.ctrls[c].GetSelection()])
                 except IndexError:
-                    config.set("main", o, 
+                    config.set("main", o,
                             guiToUni(self.ctrls[c].GetStringSelection()))
             elif t == "spin":   # Numeric SpinCtrl -> transfer number
                 config.set( "main", o, unicode(self.ctrls[c].GetValue()) )
@@ -1242,7 +1242,7 @@ class OptionsDialog(wx.Dialog):
             panel.handleOk()
 
         config.informChanged(self.oldSettings)
-        
+
         if self.activePageIndex > -1:
             OptionsDialog._lastShownPanelName = self.combinedPanelList[
                     self.activePageIndex][0]
@@ -1260,9 +1260,9 @@ class OptionsDialog(wx.Dialog):
         if dlg.ShowModal() == wx.ID_OK:
             self.ctrls.tfFacenameHtmlPreview.SetValue(dlg.GetValue())
         dlg.Destroy()
-        
+
 #     def OnSelectPageStatusTimeFormat(self, evt):
-#         dlg = DateformatDialog(self, -1, self.pWiki, 
+#         dlg = DateformatDialog(self, -1, self.pWiki,
 #                 deffmt=self.ctrls.tfPageStatusTimeFormat.GetValue())
 #         if dlg.ShowModal() == wx.ID_OK:
 #             self.ctrls.tfPageStatusTimeFormat.SetValue(dlg.GetValue())
@@ -1279,7 +1279,7 @@ class OptionsDialog(wx.Dialog):
         self.ctrls.tfTempHandlingTempDir.Enable(enabled)
         self.ctrls.btnSelectTempHandlingTempDir.Enable(enabled)
 
-        # Dimensions of image preview tooltips can only be set if tooltips are 
+        # Dimensions of image preview tooltips can only be set if tooltips are
         # enabled
         enabled = self.ctrls.cbEditorImageTooltipsLocalUrls.GetValue()
         self.ctrls.scEditorImageTooltipsMaxWidth.Enable(enabled)
@@ -1316,7 +1316,7 @@ class OptionsDialog(wx.Dialog):
         oct = self.idToOptionEntryMap[evt.GetId()]
         o, c, t = oct[:3]
         params = oct[3:]
-        
+
         if t == "color0":
             self.selectColor(self.ctrls[c])
         elif t == "ttdf":   # Date/time format
@@ -1348,25 +1348,25 @@ class OptionsDialog(wx.Dialog):
             dlg.Destroy()
 
 
-    def selectDirectory(self, tfield):        
+    def selectDirectory(self, tfield):
         seldir = wx.DirSelector(_(u"Select Directory"),
                 tfield.GetValue(),
                 style=wx.DD_DEFAULT_STYLE|wx.DD_NEW_DIR_BUTTON, parent=self)
-            
+
         if seldir:
             tfield.SetValue(seldir)
 
-    def selectFile(self, tfield, wildcard=u""):        
+    def selectFile(self, tfield, wildcard=u""):
         selfile = wx.FileSelector(_(u"Select File"),
                 tfield.GetValue(), wildcard = wildcard + u"|" + \
                         _(u"All files (*.*)|*"),
                 flags=wx.OPEN, parent=self)
-            
+
         if selfile:
             tfield.SetValue(selfile)
-            
+
     def selectDateTimeFormat(self, tfield):
-        dlg = DateformatDialog(self, -1, self.pWiki, 
+        dlg = DateformatDialog(self, -1, self.pWiki,
                 deffmt=tfield.GetValue())
         try:
             if dlg.ShowModal() == wx.ID_OK:
@@ -1380,11 +1380,11 @@ class OptionsDialog(wx.Dialog):
 
         # if fontDesc != u"":
         font = wx.SystemSettings_GetFont(wx.SYS_DEFAULT_GUI_FONT)
-            
-        # wx.Font()    # 1, wx.FONTFAMILY_DEFAULT, 
-        
+
+        # wx.Font()    # 1, wx.FONTFAMILY_DEFAULT,
+
         font.SetNativeFontInfoUserDesc(fontDesc)
-        
+
         newFont = wx.GetFontFromUser(self, font)  # , const wxString& caption = wxEmptyString)
         if newFont is not None and newFont.IsOk():
             tfield.SetValue(newFont.GetNativeFontInfoUserDesc())

--- a/lib/pwiki/WikiTxtCtrl.py
+++ b/lib/pwiki/WikiTxtCtrl.py
@@ -297,7 +297,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
         # when was a key pressed last. used to check idle time.
         self.lastKeyPressed = time()
         self.eolMode = self.GetEOLMode()
-        
+
         # Check if modifiers where pressed since last extended logical line move
         # See self.moveSelectedLinesOneUp() for the reason of this
         self.modifiersPressedSinceExtLogLineMove = False
@@ -352,21 +352,21 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
         # Passing the evt here is not strictly necessary, but it may be
         # used in the future
-        wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_THIS_LEFT, 
+        wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_THIS_LEFT,
                 lambda evt: self.OnActivateThis(evt, u"left"))
         wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_LEFT,
                 lambda evt: self.OnActivateNewTabThis(evt, u"left"))
         wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_LEFT,
                 lambda evt: self.OnActivateNewTabBackgroundThis(evt, u"left"))
 
-        wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_THIS_RIGHT, 
+        wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_THIS_RIGHT,
                 lambda evt: self.OnActivateThis(evt, u"right"))
         wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_RIGHT,
                 lambda evt: self.OnActivateNewTabThis(evt, u"right"))
         wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_NEW_TAB_BACKGROUND_THIS_RIGHT,
                 lambda evt: self.OnActivateNewTabBackgroundThis(evt, u"right"))
 
-        wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_THIS_ABOVE, 
+        wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_THIS_ABOVE,
                 lambda evt: self.OnActivateThis(evt, u"above"))
         wx.EVT_MENU(self, GUI_ID.CMD_ACTIVATE_NEW_TAB_THIS_ABOVE,
                 lambda evt: self.OnActivateNewTabThis(evt, u"above"))
@@ -504,10 +504,10 @@ class WikiTxtCtrl(SearchableScintillaControl):
             destPath = imgsav.saveWmfFromClipboardToFileStorage(fs)
             if destPath is not None:
                 url = self.presenter.getWikiDocument().makeAbsPathRelUrl(destPath)
-    
+
                 if url is None:
                     url = u"file:" + StringOps.urlFromPathname(destPath)
-    
+
                 self.ReplaceSelection(url)
                 return True
 
@@ -905,7 +905,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
             faces["mono"] = font
             self.SetStyles(faces)
             self.lastEditorFont = font
-        
+
         # this updates depending on attribute "wrap_type" (word or character)
         self.setWrapMode(self.getWrapMode())
 
@@ -1058,7 +1058,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
             self.lastEditorFont = font    # ???
 
         self._checkForReadOnly()
-        
+
         self.SetStyles(faces)
 
         color = self._getColorFromOption("editor_bg_color", (255, 255, 255))
@@ -1106,7 +1106,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
             if self.vi is None:
                 self.vi = ViHandler(self)
 
-            
+
             if not isLinux():
                 # Need to merge with OnChar_ImeWorkaround
                 self.Bind(wx.EVT_CHAR, self.vi.OnChar)
@@ -1184,7 +1184,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
             faces["mono"] = font
             self.SetStyles(faces)
             self.lastEditorFont = font
-            
+
         # this updates depending on attribute "wrap_type" (word or character)
         self.setWrapMode(self.getWrapMode())
 
@@ -1468,10 +1468,10 @@ class WikiTxtCtrl(SearchableScintillaControl):
                                 self.presenter)
                 for direction in viewports:
                     if viewports[direction] is not None:
-                        appendToMenuByMenuDesc(menu, 
+                        appendToMenuByMenuDesc(menu,
                                     _CONTEXT_MENU_INTEXT_ACTIVATE_DIRECTION[
                                             direction])
-                        
+
 
                 if addFileUrlItem:
                     appendToMenuByMenuDesc(menu, _CONTEXT_MENU_INTEXT_FILE_URL)
@@ -1703,7 +1703,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
                     linkNode.pos + linkNode.strLength)
         else:
             forbiddenSearchfragHit = (0, 0)
-        
+
         searchfrag = linkNode.searchFragment
         if searchfrag is None:
             return (-1, -1)
@@ -1711,7 +1711,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
         searchOp = SearchReplaceOperation()
         searchOp.wildCard = "no"
         searchOp.searchStr = searchfrag
-        
+
         targetPage = self.presenter.getWikiDocument().getWikiPage(
                 linkNode.wikiWord)
 
@@ -1816,7 +1816,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
         each value is a tuple (fold, recursive) where
         fold -- True iff node should be folded
         recursive -- True iff node should be processed recursively
-        
+
         The value tuples may contain more than these two items, processFolding()
         must be able to handle that.
         """
@@ -1824,7 +1824,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
         #   (or some of them)
 
         return self.wikiLanguageHelper.getFoldingNodeDict()
-        
+
 
     def processFolding(self, pageAst, threadstop):
         # TODO: allow folding of tables / boxes / figures
@@ -1833,7 +1833,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
         prevLevel = 0
         levelStack = []
         foldHeader = False
-        
+
         foldNodeDict = self.getFoldingNodeDict()
 
         def searchAst(ast, foldingseq, prevLevel, levelStack, foldHeader):
@@ -1857,35 +1857,35 @@ class WikiTxtCtrl(SearchableScintillaControl):
                     foldHeader = True
                 elif node.name in foldNodeDict:
                     fndMode = foldNodeDict[node.name][:2]
-                    
+
                     if fndMode == (True, False):  # Fold, non recursive
                         # No point in folding single line items
                         if node.getString().count(u"\n") > 1:
                             levelStack.append(("node", 0))
                             foldHeader = True
-    
+
                     elif fndMode == (True, True):  # Fold, recursive
                         levelStack.append(("recursive-node", 0))
                         foldHeader = True
                         foldingseq, prevLevel, levelStack, foldHeader = \
-                                searchAst(node, foldingseq, prevLevel, levelStack, 
+                                searchAst(node, foldingseq, prevLevel, levelStack,
                                 foldHeader)
                         while levelStack[-1][0] == "heading":
                             del levelStack[-1]
-                            
+
                         del levelStack[-1]
-    
+
                         recursive = True
-    
+
                     elif fndMode == (False, True):  # No fold, but recursive
                         foldingseq, prevLevel, levelStack, foldHeader = \
-                                searchAst(node, foldingseq, prevLevel, levelStack, 
+                                searchAst(node, foldingseq, prevLevel, levelStack,
                                 foldHeader)
                         recursive = True
 
                 if not recursive:
                     lfc = node.getString().count(u"\n")
-                    
+
                     if len(levelStack) > prevLevel:
                         foldHeader = True
 
@@ -1905,7 +1905,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
             return foldingseq, prevLevel, levelStack, foldHeader
 
-        foldingseq, prevLevel, levelStack, foldHeader = searchAst(pageAst, 
+        foldingseq, prevLevel, levelStack, foldHeader = searchAst(pageAst,
                 foldingseq, prevLevel, levelStack, foldHeader)
 
         # final line
@@ -2111,19 +2111,19 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
 
     def formatSelection(self, formatType):
-        start, afterEnd = self.GetSelectionCharPos()    
+        start, afterEnd = self.GetSelectionCharPos()
         info = self.wikiLanguageHelper.formatSelectedText(self.GetText(),
                 start, afterEnd, formatType, {})
         if info is None:
             return False
-        
+
         replacement, repStart, repAfterEnd, selStart, selAfterEnd = info[:5]
-        
+
         self.SetSelectionByCharPos(repStart, repAfterEnd)
         self.ReplaceSelection(replacement)
         self.SetSelectionByCharPos(selStart, selAfterEnd)
-        return True    
-        
+        return True
+
 
     def getPageAst(self):
         docPage = self.getLoadedDocPage()
@@ -2387,7 +2387,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
     def OnActivateThis(self, evt, direction=None):
         ed = self.GetEditorToActivate(direction, True)
-            
+
         if self.contextMenuTokens:
             ed.activateTokens(self.contextMenuTokens, 0)
 
@@ -2410,7 +2410,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
     def OnActivateNewWindowThis(self, evt, direction=None):
         ed = self.GetEditorToActivate(direction, True)
-        
+
         if self.contextMenuTokens:
             ed.activateTokens(self.contextMenuTokens, 6)
 
@@ -2449,9 +2449,9 @@ class WikiTxtCtrl(SearchableScintillaControl):
                             node.url)
                     if link is None:
                         continue
-                    
+
 #                     link = node.url
-# 
+#
 #                     if link.startswith(u"rel://"):
 #                         link = StringOps.pathnameFromUrl(self.presenter.getMainControl().makeRelUrlAbsolute(link))
 #                     else:
@@ -2477,7 +2477,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
                                 node.pos + node.strLength)
                     return
 
-        
+
     def OnRenameFile(self, evt):
         if not self.contextMenuTokens:
             return
@@ -2493,7 +2493,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
 
 #                 link = node.url
-# 
+#
 #                 if link.startswith(u"rel://"):
 #                     link = StringOps.pathnameFromUrl(self.presenter.getMainControl().makeRelUrlAbsolute(link))
 #                 else:
@@ -2521,7 +2521,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
             dlg.Destroy()
 
             newfile = join(path, newName)
-            
+
             if exists(newfile):
                 if not isfile(newfile):
                     self.presenter.displayErrorMessage(
@@ -2539,9 +2539,9 @@ class WikiTxtCtrl(SearchableScintillaControl):
                     continue
 
             # Either file doesn't exist or user allowed overwrite
-            
+
             OsAbstract.moveFile(link, newfile)
-            
+
             if node.url.startswith(u"rel://"):
                 # Relative URL/path
                 newUrl = self.presenter.getWikiDocument().makeAbsPathRelUrl(
@@ -2570,13 +2570,13 @@ class WikiTxtCtrl(SearchableScintillaControl):
                 if link.startswith(u"rel://") or link.startswith(u"wikirel://"):
                     link = self.presenter.getWikiDocument()\
                             .makeRelUrlAbsolute(link, addSafe=addSafe)
-                            
+
                 else:
                     link = self.presenter.getWikiDocument()\
                             .makeAbsUrlRelative(link, addSafe=addSafe)
                     if link is None:
                         continue # TODO Message?
-                    
+
                 self.replaceTextAreaByCharPos(link, node.coreNode.pos,
                         node.coreNode.pos + node.coreNode.strLength)
 
@@ -3047,12 +3047,12 @@ class WikiTxtCtrl(SearchableScintillaControl):
         """
         Extend current selection to full logical lines and move selected lines
         upward one line.
-        
+
         extendOverChildren -- iff true, extend selection over lines more indented
             below the initial selection. It should only be set True for first move
             in a sequence of moves (until all modifier keys are released) otherwise:
-            
-            If you have e.g. 
+
+            If you have e.g.
             A
                 B
             C
@@ -3061,7 +3061,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
             and move up C with children two times then B would be moved above A
             as well which is not intended
         """
-        
+
         self.BeginUndoAction()
         try:
             selByteStart, selByteEnd = self._getExpandedByteSelectionToLine(
@@ -3134,7 +3134,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
     def OnKeyUp(self, evt):
         evt.Skip()
-        
+
         if not self.modifiersPressedSinceExtLogLineMove:
             return
 
@@ -3144,7 +3144,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
     def OnKeyDown(self, evt):
         key = evt.GetKeyCode()
-        
+
         self.lastKeyPressed = time()
         accP = getAccelPairFromKeyDown(evt)
         matchesAccelPair = self.presenter.getMainControl().keyBindings.\
@@ -3155,7 +3155,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 #                     (wx.ACCEL_ALT, wx.WXK_UP),
 #                     (wx.ACCEL_SHIFT | wx.ACCEL_ALT, wx.WXK_NUMPAD_UP),
 #                     (wx.ACCEL_SHIFT | wx.ACCEL_ALT, wx.WXK_UP) ):
-# 
+#
 #                 self.moveSelectedLinesOneUp(accP[0] & wx.ACCEL_SHIFT)
 #                 return
 #             elif accP in ( (wx.ACCEL_ALT, wx.WXK_NUMPAD_DOWN),
@@ -3165,7 +3165,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 #
 #                 self.moveSelectedLinesOneDown(accP[0] & wx.ACCEL_SHIFT)
 #                 return
-# 
+#
 #             evt.Skip()
 
 
@@ -3287,7 +3287,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
         # Scintilla's wheel zoom behavior is unusual (upward=zoom out)
         # So the sign of rotation value must be changed if wheel zoom is NOT
         # reversed by option
-        
+
         if evt.ControlDown() and not self.presenter.getConfig().getboolean(
                 "main", "mouse_reverseWheelZoom", False):
             evt.m_wheelRotation = -evt.m_wheelRotation
@@ -3297,7 +3297,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
     def OnLogicalLineMove(self, evt):
         evtId = evt.GetId()
-        
+
         if evtId == GUI_ID.CMD_LOGICAL_LINE_UP:
             self.moveSelectedLinesOneUp(False)
         elif evtId == GUI_ID.CMD_LOGICAL_LINE_UP_WITH_INDENT:
@@ -3320,7 +3320,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
 
             # We need to make sure makeCurrent uses CallAfter overwise we
             # get a selection bug if the mouse is moved quickly after
-            # clicking on the TxtCtrl (not sure if this is required for 
+            # clicking on the TxtCtrl (not sure if this is required for
             # windows)
             wx.CallAfter(self.presenter.makeCurrent)
             evt.Skip()
@@ -3501,7 +3501,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
                         appendixDict = {}
                     else:
                         appendixDict = dict(astNode.appendixNode.entries)
-            
+
                     # Decide if this is an image link
                     if appendixDict.has_key("l"):
                         urlAsImage = False
@@ -3565,17 +3565,17 @@ class WikiTxtCtrl(SearchableScintillaControl):
 #
 #                        lines = callTip.split("\n")
 #                        formatedLines = []
-#                        
+#
 #                        # By default wrap ignores newlines so rewrap each line
 #                        # seperately
 #                        for line in lines:
 #                            formatedLines.append("\n".join(textwrap.wrap(line, maxTextLen)))
 #
 #                        callTip = "\n".join(formatedLines)
-                            
-                    bytePos = bytePos - self.GetColumn(bytePos) 
-                    
-                
+
+                    bytePos = bytePos - self.GetColumn(bytePos)
+
+
                 # TODO: FIX
                 callInMainThread(self.CallTipShow, bytePos, callTip)
 
@@ -3586,7 +3586,7 @@ class WikiTxtCtrl(SearchableScintillaControl):
     def dwellLock(self):
         if self.dwellLockCounter == 0:
             self.OnDwellEnd(None)
-        
+
         self.dwellLockCounter += 1
         yield
         self.dwellLockCounter -= 1
@@ -3859,7 +3859,7 @@ class WikiTxtCtrlDropTarget(wx.PyDropTarget):
             suffix = u"/modkeys/shift"
         else:
             suffix = u""
-            
+
         mc.getUserActionCoord().reactOnUserEvent(
                 u"mouse/leftdrop/editor/files" + suffix, paramDict)
 
@@ -4079,7 +4079,7 @@ class ImageTooltipPanel(wxPopupOrFrame):
         self.url = filePath
         self.pWiki = pWiki
         self.firstMove = True
-        
+
         img = wx.Image(filePath, wx.BITMAP_TYPE_ANY)
 
         origWidth = img.GetWidth()
@@ -4094,7 +4094,7 @@ class ImageTooltipPanel(wxPopupOrFrame):
         if origWidth > 0 and origHeight > 0:
             self.width, self.height = calcResizeArIntoBoundingBox(origWidth,
                     origHeight, maxWidth, maxHeight)
-            
+
             img.Rescale(self.width, self.height, quality = wx.IMAGE_QUALITY_HIGH)
         else:
             self.width = origWidth
@@ -4104,7 +4104,7 @@ class ImageTooltipPanel(wxPopupOrFrame):
 
         self.SetSize((self.width, self.height))
 
-        self.bmp = wx.StaticBitmap(self, -1, img, (0, 0), (img.GetWidth(), 
+        self.bmp = wx.StaticBitmap(self, -1, img, (0, 0), (img.GetWidth(),
                 img.GetHeight()))
         self.bmp.Bind(wx.EVT_LEFT_DOWN, self.OnLeftClick)
         self.bmp.Bind(wx.EVT_RIGHT_DOWN, self.OnRightClick)
@@ -4120,7 +4120,7 @@ class ImageTooltipPanel(wxPopupOrFrame):
 
         self.Show()
         # Works for Windows (but not for GTK), maybe also for Mac (MB)
-        self.GetParent().SetFocus()  
+        self.GetParent().SetFocus()
 
     def Close(self, event=None):
         self.Destroy()
@@ -4159,7 +4159,7 @@ class ViHandler(ViHelper):
     # TODO: Add search commands
     #       repeat visual actions
     #       scroll cursor on mousewheel at viewport top/bottom
-    
+
     def __init__(self, stc):
         ViHelper.__init__(self, stc)
 
@@ -4201,7 +4201,7 @@ class ViHandler(ViHelper):
                     "'" : (True, self.SelectInSingleQuote),
                     "`" : (True, self.SelectInTilde),
 
-                    # The commands below are not present in vim but may 
+                    # The commands below are not present in vim but may
                     # be useful for quickly editing parser syntax
                     u"\xc2" : (True, self.SelectInPoundSigns),
                     u"$" : (True, self.SelectInDollarSigns),
@@ -4361,7 +4361,7 @@ class ViHandler(ViHelper):
     (k["T"], "*")  : (2, (self.FindUpToNextCharBackwards, None), 5, 0), # T*
     (k["r"], "*") : (0, (self.ReplaceChar, None), 0, 0), # r*
 
-    (k["d"], k["c"], u"m", u"*") : (0, (self.DeleteCharMotion, 
+    (k["d"], k["c"], u"m", u"*") : (0, (self.DeleteCharMotion,
                                             False), 1, 0), # dcmotion*
 
     (k["i"],) : (0, (self.Insert, None), 2, 0), # i
@@ -4418,7 +4418,7 @@ class ViHandler(ViHelper):
     (k["g"], k["$"])  : (2, (self.GotoVisualLineEnd, None), 1, 0), # g$
 
     # Arrow keys
-    (wx.WXK_LEFT,) : (2, (self.MoveCaretLeft, None), 0, 0), # left 
+    (wx.WXK_LEFT,) : (2, (self.MoveCaretLeft, None), 0, 0), # left
     (wx.WXK_UP,) : (2, (self.MoveCaretUp, None), 0, 0), # up
     (wx.WXK_RIGHT,) : (2, (self.MoveCaretRight, False), 0, 0), # right
     (wx.WXK_DOWN,) : (2, (self.MoveCaretDown, None), 0, 0), # down
@@ -4430,7 +4430,7 @@ class ViHandler(ViHelper):
     (k["$"],)    : (1, (self.GotoLineEnd, False), 0, 0), # $
     (wx.WXK_END,) : (1, (self.GotoLineEnd, False), 0, 0), # end
     (k["0"],)    : (2, (self.GotoLineStart, None), 0, 0), # 0
-    (wx.WXK_HOME,) : (2, (self.GotoLineStart, None), 0, 0), # home 
+    (wx.WXK_HOME,) : (2, (self.GotoLineStart, None), 0, 0), # home
     (k["-"],)    : (1, (self.GotoLineIndentPreviousLine, None), 0, 0), # -
     (k["+"],)    : (1, (self.GotoLineIndentNextLine, None), 0, 0), # +
     (k["^"],)    : (2, (self.GotoLineIndent, None), 0, 0), # ^
@@ -4452,22 +4452,22 @@ class ViHandler(ViHelper):
     (k["z"], k["t"])  : (0, (self.ScrollViewportTop, None), 0, 0), # zt
     (k["z"], k["b"])   : (0, (self.ScrollViewportBottom, None), 0, 0), # zb
 
-    (("Ctrl", k["u"]),)    : (0, (self.ScrollViewportUpHalfScreen, 
+    (("Ctrl", k["u"]),)    : (0, (self.ScrollViewportUpHalfScreen,
                                                         None), 0, 0), # <c-u>
-    (("Ctrl", k["d"]),)    : (0, (self.ScrollViewportDownHalfScreen, 
+    (("Ctrl", k["d"]),)    : (0, (self.ScrollViewportDownHalfScreen,
                                                         None), 0, 0), # <c-d>
-    (("Ctrl", k["b"]),)     : (0, (self.ScrollViewportUpFullScreen, 
+    (("Ctrl", k["b"]),)     : (0, (self.ScrollViewportUpFullScreen,
                                                         None), 0, 0), # <c-b>
-    (("Ctrl", k["f"]),)    : (0, (self.ScrollViewportDownFullScreen, 
+    (("Ctrl", k["f"]),)    : (0, (self.ScrollViewportDownFullScreen,
                                                         None), 0, 0), # <c-f>
 
-    (("Ctrl", k["e"]),)    : (0, (self.ctrl.LineScrollDown, 
+    (("Ctrl", k["e"]),)    : (0, (self.ctrl.LineScrollDown,
                                                         None), 0, 0), # <c-e>
-    (("Ctrl", k["y"]),)    : (0, (self.ctrl.LineScrollUp, 
+    (("Ctrl", k["y"]),)    : (0, (self.ctrl.LineScrollUp,
                                                         None), 0, 0), # <c-y>
-#    (("Ctrl", k["e"]),)    : (0, (self.ScrollViewportLineDown, 
+#    (("Ctrl", k["e"]),)    : (0, (self.ScrollViewportLineDown,
 #                                                        None), 0, 0), # <c-e>
-#    (("Ctrl", k["y"]),)    : (0, (self.ScrollViewportLineUp, 
+#    (("Ctrl", k["y"]),)    : (0, (self.ScrollViewportLineUp,
 #                                                        None), 0, 0), # <c-y>
 
     (k["Z"], k["Z"])    : (0, (self.ctrl.presenter.getMainControl().\
@@ -4563,7 +4563,7 @@ class ViHandler(ViHelper):
     (("Ctrl", k["w"]), k["k"])  : (0, (self.ctrl.presenter.getMainControl().getMainAreaPanel().switchPresenterByPosition, "above"), 0, 0), # <c-w>l
 
     #(k["g"], k["s"])  : (0, (self.SwitchEditorPreview, None), 0), # gs
-    
+
     # TODO: think of suitable commands for the following
     (wx.WXK_F3,)     : (0, (self.SwitchEditorPreview, "textedit"), 0, 0), # F3
     (wx.WXK_F4,)     : (0, (self.SwitchEditorPreview, "preview"), 0, 0), # F4
@@ -4582,7 +4582,7 @@ class ViHandler(ViHelper):
         self.keys[1] = {
     # TODO:
     #(("Ctrl", 64),)  : (0, (self.InsertPreviousText, None), 0), # Ctrl-@
-    #(("Ctrl", k["a"]),)  : (0, (self.InsertPreviousTextLeaveInsertMode, 
+    #(("Ctrl", k["a"]),)  : (0, (self.InsertPreviousTextLeaveInsertMode,
     #                                                    None), 0), # Ctrl-a
     (("Ctrl", k["n"]),)  : (0, (self.Autocomplete, True), 0, 0), # Ctrl-n
     (("Ctrl", k["p"]),)  : (0, (self.Autocomplete, False), 0, 0), # Ctrl-p
@@ -4641,8 +4641,8 @@ class ViHandler(ViHelper):
     (k["g"], k["s"]) : (0, (self.SelectionToSubscript, None), 1, 0), # gs
     (k["g"], k["S"]) : (0, (self.SelectionToSuperscript, None), 1, 0), # gS
 
-    (k["\\"], k["d"], k["c"], u"*") : (0, (self.DeleteCharFromSelection, 
-                                                    None), 1), # \dc* 
+    (k["\\"], k["d"], k["c"], u"*") : (0, (self.DeleteCharFromSelection,
+                                                    None), 1), # \dc*
 
     # Use Ctrl-r in visual mode to start a replace
     (("Ctrl", k["r"]),)    : (0, (self.StartReplaceOnSelection, None), 1, 0), # <c-r>
@@ -4673,7 +4673,7 @@ class ViHandler(ViHelper):
         self.GenerateKeyAccelerators(self.keys)
 
     def ApplySettings(self):
-        # Set wrap indent mode 
+        # Set wrap indent mode
         self.ctrl.SendMsg(2472, self.settings["set_wrap_indent_mode"])
 
         #self.ctrl.SendMsg(, self.settings["set_wrap_start_indent"])
@@ -4703,7 +4703,7 @@ class ViHandler(ViHelper):
         It would be nice to set caret alpha but i don't think its
         possible at the moment
         """
-        
+
         if mode is None:
             mode = self.mode
         else:
@@ -4773,7 +4773,7 @@ class ViHandler(ViHelper):
     # Need to overide Undo and Redo to goto positions
     # TODO: Tidy up
     def BeginUndo(self, use_start_pos=True, force=False):
-        
+
         if self._undo_state == 0:
             self.ctrl.BeginUndoAction()
             print "START UNDO"
@@ -4795,7 +4795,7 @@ class ViHandler(ViHelper):
             if self._undo_start_position is not None:
                 self._undo_positions.append(self._undo_start_position)
                 self._undo_start_position = None
-                
+
             elif self.HasSelection:
                 self._undo_positions.append(self.ctrl.GetSelectionStart())
             else:
@@ -4812,7 +4812,7 @@ class ViHandler(ViHelper):
         if self._undo_start_position is not None:
             self._undo_positions.append(self._undo_start_position)
             self._undo_start_position = None
-            
+
         elif self.HasSelection:
             self._undo_positions.append(self.ctrl.GetSelectionStart())
         else:
@@ -4884,7 +4884,7 @@ class ViHandler(ViHelper):
         current_line = self.ctrl.GetCurrentLine()
         if evt.GetWheelRotation() < 0:
             if current_line <= self.GetFirstVisibleLine():
-                
+
                 for i in range(evt.GetLinesPerAction()):
                     #self.ctrl.LineDown()
                     self.ctrl.LineScrollDown()
@@ -4892,7 +4892,7 @@ class ViHandler(ViHelper):
         else:
             if current_line >= self.GetLastVisibleLine() - \
                     evt.GetLinesPerAction() - 1:
-                
+
                 for i in range(evt.GetLinesPerAction()):
                     #self.ctrl.LineUp()
                     self.ctrl.LineScrollUp()
@@ -4911,7 +4911,7 @@ class ViHandler(ViHelper):
             #        func = self.ctrl.LineDown
             #else:
             #        func = self.ctrl.LineUp
-            #    
+            #
             #for i in range(abs(offset)):
             #    print "i", i
             #    func()
@@ -4925,7 +4925,7 @@ class ViHandler(ViHelper):
 #        viewport movements
 #        """
 #        # NOTE: may be inefficient?
-#        #       perhaps use EVT_SCROLLWIN_LINEUP 
+#        #       perhaps use EVT_SCROLLWIN_LINEUP
 #        current_line = self.ctrl.GetCurrentLine()
 #        top_line = self.GetFirstVisibleLine()+1
 #        bottom_line = self.GetLastVisibleLine()-1
@@ -4993,10 +4993,10 @@ class ViHandler(ViHelper):
                 return
 
         evt.Skip()
-        
 
 
-            
+
+
     def TurnOff(self):
         self._enableMenuShortcuts(True)
         self.ctrl.SetCaretWidth(1)
@@ -5013,12 +5013,12 @@ class ViHandler(ViHelper):
         return self.ctrl.GetTextRange(start, end)
 
     def EmulateKeypresses(self, actions):
-        # NOTE: wxstyledtextctrl supports macros which would probably be a 
+        # NOTE: wxstyledtextctrl supports macros which would probably be a
         #       better solution for much of this.
         if len(actions) > 0:
 
             eol = self.ctrl.GetEOLChar()
-            
+
             for i in actions:
                 # TODO: handle modifier keys, e.g. ctrl
                 if i == wx.WXK_LEFT:
@@ -5039,7 +5039,7 @@ class ViHandler(ViHelper):
                 else:
                     self.ctrl.InsertText(self.ctrl.GetCurrentPos(), unichr(i))
                     self.ctrl.CharRight()
-        
+
     def _RepeatCmdHelper(self):
         self.visualBell("GREEN")
         #self.BeginUndo()
@@ -5056,12 +5056,12 @@ class ViHandler(ViHelper):
         actions = self.insert_action
         # NOTE: Is "." only going to repeat editable commands as in vim?
         if cmd_type == 1:
-            self.RunFunction(key, motion, motion_wildcards, wildcards, 
+            self.RunFunction(key, motion, motion_wildcards, wildcards,
                                                 text_to_select, repeat=True)
         # If a command ends in insertion mode we also repeat any changes
         # made up until the next mode change.
         elif cmd_type == 2: # + insertion
-            self.RunFunction(key, motion, motion_wildcards, wildcards, 
+            self.RunFunction(key, motion, motion_wildcards, wildcards,
                                                 text_to_select, repeat=True)
             # Emulate keypresses
             # Return to normal mode
@@ -5071,7 +5071,7 @@ class ViHandler(ViHelper):
             self.ReplaceChar(key)
         #self.EndUndo()
         self.insert_action = actions
-    
+
     def RepeatCmd(self):
         # TODO: move to ViHelper?
         if self.last_cmd is not None:
@@ -5196,10 +5196,10 @@ class ViHandler(ViHelper):
                 # Bad ordering at the moment
                 text = self.ctrl.GetTextRange(
                             self.ctrl.GetCurrentPos(), self.ctrl.GetLength())
-                completion_list = re.findall(ur"\b{0}.*?\b".format(re.escape(word)), 
+                completion_list = re.findall(ur"\b{0}.*?\b".format(re.escape(word)),
                         text, re.U)
                 text = self.ctrl.GetTextRange(0, self.ctrl.GetCurrentPos())
-                completion_list.extend(re.findall(ur"\b{0}.*?\b".format(word), 
+                completion_list.extend(re.findall(ur"\b{0}.*?\b".format(word),
                         text, re.U))
                 completions.add(word)
 
@@ -5257,7 +5257,7 @@ class ViHandler(ViHelper):
         #    mid = (fl + (self.GetLineCount() / 2))
         return mid
 
-        
+
     def GotoSelectionStart(self):
         self.ctrl.GotoPos(self.ctrl.GetSelectionStart())
 
@@ -5317,7 +5317,7 @@ class ViHandler(ViHelper):
 
     def GetUnichrAt(self, pos):
         """
-        Returns the character under the caret. 
+        Returns the character under the caret.
         Works with unicode characters.
         """
         return self.ctrl.GetTextRange(pos, self.ctrl.PositionAfter(pos))
@@ -5344,7 +5344,7 @@ class ViHandler(ViHelper):
         ( ) etc...).
         """
         if ob in self.text_object_map:
-            between, cmd = self.text_object_map[ob] 
+            between, cmd = self.text_object_map[ob]
 
             if between:
                 cmd(extra)
@@ -5410,10 +5410,10 @@ class ViHandler(ViHelper):
 
     def SelectInWORD(self, extra=False):
         self._SelectInWords(True, extra=extra)
-        
+
     def _SelectInWords(self, WORD=False, extra=False):
         # NOTE: in VIM direction depends on selection stream direction
-        #       there are still a number of difference between this 
+        #       there are still a number of difference between this
         #       and vims implementation
 
         # NOTE: Does not select single characters
@@ -5494,7 +5494,7 @@ class ViHandler(ViHelper):
         self.ctrl.CharLeft()
         self.SelectSelection(2)
 
-    def _SelectInBracket(self, bracket, extra=False, start_pos=None, 
+    def _SelectInBracket(self, bracket, extra=False, start_pos=None,
             count=None, linewise=False, ignore_forewardslashes=False):
         # TODO: config option to "delete preceeding whitespace"
         if start_pos is None: start_pos = self.ctrl.GetCurrentPos()
@@ -5530,7 +5530,7 @@ class ViHandler(ViHelper):
                                 sel_start = self.StartSelection(sel_start+1)
                             if self.GetUnichrAt(sel_start) == u"/":
                                 sel_start = self.StartSelection(sel_start+1)
-                            
+
                         self.ctrl.GotoPos(sel_end - len(bracket))
                         #self.ctrl.SetSelection(sel_start+len(bracket), sel_end-len(bracket))
                         #self.ctrl.CharLeftExtend()
@@ -5594,7 +5594,7 @@ class ViHandler(ViHelper):
         """
         Select in between "char" blocks.
 
-        If "forward_char" is not None will select between "char" and 
+        If "forward_char" is not None will select between "char" and
         "forward_char".
 
         Note:
@@ -5614,7 +5614,7 @@ class ViHandler(ViHelper):
                     self.ctrl.CharLeftExtend()
                     self.StartSelection(start_pos+len(char))
                     self.SelectSelection(2)
-                    
+
                 else:
                     for i in range(1, len(forward_char)):
                         self.ctrl.CharRightExtend()
@@ -5716,8 +5716,8 @@ class ViHandler(ViHelper):
             self.ctrl.SetSelection(sel_start, sel_end-1)
             text = self.ctrl.GetSelectedText()
 
-        replacements = self.SURROUND_REPLACEMENTS 
-        
+        replacements = self.SURROUND_REPLACEMENTS
+
         if new_line:
             text = "\n{0}\n".format(text)
 
@@ -5763,7 +5763,7 @@ class ViHandler(ViHelper):
                 else:
                     if line_pos >= len(bytes(line_text)) - 1:
                         self.ctrl.CharLeft()
-                
+
     def OnLastLine(self):
         return self.ctrl.GetCurrentLine() + 1 == self.ctrl.GetLineCount()
 
@@ -5789,7 +5789,7 @@ class ViHandler(ViHelper):
         if it can be made to work. (retest with wx >= 2.9)
         """
         start_line, end_line = self._GetSelectedLines(exclusive=True)
-        
+
         if self.ctrl.GetCurrentPos() >= self.GetSelectionAnchor():
             reverse = False
 
@@ -5809,7 +5809,7 @@ class ViHandler(ViHelper):
             reverse = True
             end_line -= 1
 
-        self.SelectLines(start_line, end_line, reverse=reverse, 
+        self.SelectLines(start_line, end_line, reverse=reverse,
                 include_eol=include_eol)
 
 
@@ -5841,7 +5841,7 @@ class ViHandler(ViHelper):
 
             if i == 0:
                 new_text.append(line)
-            else:   
+            else:
                 if ViHelper.STRIP_BULLETS_ON_LINE_JOIN:
                     # TODO: roman numerals
                     # It may be better to avoid using a regex here?
@@ -5875,7 +5875,7 @@ class ViHandler(ViHelper):
         self.ctrl.ReplaceSelection(new_text)
         self.SetLineColumnPos()
         self.EndUndo()
-        
+
 
     def DeleteBackword(self, word=False):
         if word:
@@ -5910,7 +5910,7 @@ class ViHandler(ViHelper):
         lines and selects and selects all the text. Will select the EOL char
         if required.
 
-        @return: True if multiple lines are selected in their entirety. 
+        @return: True if multiple lines are selected in their entirety.
         """
         sel_start, sel_end = self._GetSelectionRange()
 
@@ -5988,7 +5988,7 @@ class ViHandler(ViHelper):
 
         """
         return self.ctrl.GetCurrentPos() > self.ctrl.GetSelectionStart()
-        
+
 
     def SelectSelection(self, com_type=0):
         if com_type < 1:
@@ -6010,7 +6010,7 @@ class ViHandler(ViHelper):
         # Inclusive motion commands select the last character as well
         elif com_type != 2:
             self.ctrl.CharRightExtend()
-            
+
     def SelectionOnSingleLine(self):
         """
         Assume that if an EOL char is present we have mutiple lines
@@ -6339,7 +6339,7 @@ class ViHandler(ViHelper):
     def EnterLineVisualMode(self):
         """
         Enter line visual mode
-        
+
         Sets a special type of visual mode in which only full lines can
         be selected.
 
@@ -6347,7 +6347,7 @@ class ViHandler(ViHelper):
         Should be possible using StyledTextCtrl.SetSelectionType() but
         for some reason I can't get it to work so a SetSelMode() has
         been implemented.
-        
+
         """
         self.SetSelMode("LINE")
         text, pos = self.ctrl.GetCurLine()
@@ -6367,7 +6367,7 @@ class ViHandler(ViHelper):
     def EnterVisualMode(self, mouse=False):
         """
         Change to visual (selection) mode
-        
+
         Will do nothing if already in visual mode
 
         @param mouse: Visual mode was started by mouse action
@@ -6392,7 +6392,7 @@ class ViHandler(ViHelper):
     #--------------------------------------------------------------------
     # Searching
     #--------------------------------------------------------------------
-    def SearchForwardsForChar(self, search_char, count=None, 
+    def SearchForwardsForChar(self, search_char, count=None,
                                     wrap_lines=True, start_offset=0):
         """
         Search for "char".
@@ -6411,10 +6411,10 @@ class ViHandler(ViHelper):
         n = 0
         for i in range(count):
             pos = text.find(search_char, pos + 1)
-            
+
         if pos > -1:
             if not wrap_lines:
-                
+
                 text_to_check = self.ctrl.GetTextRange(start_pos, pos)
                 if self.ctrl.GetEOLChar() in text_to_check:
                     return False
@@ -6425,7 +6425,7 @@ class ViHandler(ViHelper):
         self.visualBell("RED")
         return False
 
-    def SearchBackwardsForChar(self, search_char, count=None, 
+    def SearchBackwardsForChar(self, search_char, count=None,
                                     wrap_lines=True, start_offset=0):
         """
         Searches backwards in text for character.
@@ -6518,15 +6518,15 @@ class ViHandler(ViHelper):
     def FindChar(self, code=None, reverse=False, offset=0, count=1, \
                                                             repeat=True):
         """
-        Searches current *line* for specified character. 
-        
+        Searches current *line* for specified character.
+
         Will move the caret to this place (+/- any offset supplied).
 
         @param code: keycode of character to search for.
         @param reverse: If True will search backwards.
         @param offset: Offset to move caret post search.
         @param count: Number of characters to find. If not all found,
-            i.e. count is 3 but only 2 characters on current line, will 
+            i.e. count is 3 but only 2 characters on current line, will
             not move caret.
         @param repeat: Should the search be saved so it will be
             repeated (by "," and ";")
@@ -6540,12 +6540,12 @@ class ViHandler(ViHelper):
         # Weird stuff happens when searching for a unicode string
         char = bytes(self.GetCharFromCode(code))
         pos = self.ctrl.GetCurrentPos()
-        
+
         if repeat:
             # First save cmd so it can be repeated later
             # Vim doesn't save the count so a new one can be used next time
             self.last_find_cmd = {
-                                            "code": code, 
+                                            "code": code,
                                             "reverse": reverse,
                                             "offset": offset,
                                             "repeat": False
@@ -6559,7 +6559,7 @@ class ViHandler(ViHelper):
         else: # Search forwards
             search_cmd = self.SearchForwardsForChar
             start_offset = 0
-         
+
         if search_cmd(char, count, False, start_offset):
             self.MoveCaretPos(offset)
             self.SetLineColumnPos()
@@ -6569,13 +6569,13 @@ class ViHandler(ViHelper):
 
     def FindNextChar(self, keycode):
         return self.FindChar(keycode, count=self.count)
-        
+
     def FindNextCharBackwards(self, keycode):
         return self.FindChar(keycode, count=self.count, reverse=True)
 
     def FindUpToNextChar(self, keycode):
         return self.FindChar(keycode, count=self.count, offset=-1)
-        
+
     def FindUpToNextCharBackwards(self, keycode):
         return self.FindChar(keycode, count=self.count, reverse=True, offset=-1)
 
@@ -6584,14 +6584,14 @@ class ViHandler(ViHelper):
 
     def RepeatLastFindCharCmd(self):
         args = self.GetLastFindCharCmd()
-        if args is not None: 
+        if args is not None:
             # Set the new count
             args["count"] = self.count
             return self.FindChar(**args)
-        
+
     def RepeatLastFindCharCmdReverse(self):
         args = self.GetLastFindCharCmd()
-        if args is not None: 
+        if args is not None:
             args["count"] = self.count
             args["reverse"] = not args["reverse"]
             self.FindChar(**args)
@@ -6606,7 +6606,7 @@ class ViHandler(ViHelper):
             return self.FindMatchingBrace(brace)
 
     # TODO: vim like searching
-    def _SearchText(self, text, forward=True, match_case=True, wrap=True, 
+    def _SearchText(self, text, forward=True, match_case=True, wrap=True,
             whole_word=True, regex=False, word_start=False, select_text=False,
                                             repeat_search=False):
         """
@@ -6615,13 +6615,13 @@ class ViHandler(ViHelper):
         @param text: text to search for
         @param forward: if true searches forward in text, else
                         search in reverse
-        @param match_case: should search be case sensitive?  
+        @param match_case: should search be case sensitive?
         """
 
         if repeat_search:
             offset = 2 if forward else -1
             self.MoveCaretPos(offset)
-        
+
         if not forward and self.HasSelection():
             self.ctrl.GotoPos(self.ctrl.GetSelectionEnd()+1)
         #elif forward:
@@ -6633,7 +6633,7 @@ class ViHandler(ViHelper):
         search_cmd = self.ctrl.SearchNext if forward else self.ctrl.SearchPrev
 
         flags = 0
-        
+
         if whole_word:
             flags = flags | wx.stc.STC_FIND_WHOLEWORD
         if match_case:
@@ -6669,9 +6669,9 @@ class ViHandler(ViHelper):
 
         @param forward: if true searches forward in text, else
                         search in reverse
-        @param match_case: should search be case sensitive?  
+        @param match_case: should search be case sensitive?
         @param whole_word: must the entire string match as a word
-        """ 
+        """
         self.SelectInWord()
         # this should probably be rewritten
         self.ctrl.CharRightExtend()
@@ -6685,9 +6685,9 @@ class ViHandler(ViHelper):
             self.ctrl.CharLeft()
         self.ctrl.SearchAnchor()
         self._SearchText(text, forward, match_case=match_case, wrap=True, whole_word=whole_word)
-        
-        self.last_search_args = {'text' : text, 'forward' : forward, 
-                                 'match_case' : match_case, 
+
+        self.last_search_args = {'text' : text, 'forward' : forward,
+                                 'match_case' : match_case,
                                  'whole_word' : whole_word}
 
     def SearchCaretWordForwards(self):
@@ -6719,7 +6719,7 @@ class ViHandler(ViHelper):
 
         # \V is used as we want a direct text replace
         self.StartCmdInput("%s/\V{0}/".format(text))
-    
+
     def ReplaceChar(self, keycode):
         """
         Replaces character under caret
@@ -6742,12 +6742,12 @@ class ViHandler(ViHelper):
         else:
             count = self.count
 
-        # Replace does not wrap lines and fails if you try and replace 
+        # Replace does not wrap lines and fails if you try and replace
         # non existent chars
         line, pos = self.ctrl.GetCurLineRaw()
         line_length = len(line)
 
-        # If we are on the last line we need to increase the line 
+        # If we are on the last line we need to increase the line
         # length by 1 (as the last line has no eol char)
         if self.ctrl.GetLineCount() == self.ctrl.GetCurrentLine() + 1:
             line_length += 1
@@ -6771,7 +6771,7 @@ class ViHandler(ViHelper):
         #self.Repeat(self.InsertText, arg=char)
         #if pos + count != line_length:
         #    self.MoveCaretPos(-1)
-        
+
         self.ctrl.CharLeft()
         self.SetLineColumnPos()
         self.EndUndo()
@@ -6840,7 +6840,7 @@ class ViHandler(ViHelper):
     def YankSelection(self, lines=False, yank_register=False):
         """
         Copy the current selection to the clipboard
-        
+
         Sets the currently selected register and either the yank ("0)
         or other number register depending on the value of yank_register
         """
@@ -6869,7 +6869,7 @@ class ViHandler(ViHelper):
     def Put(self, before, count=None):
         count = count if count is not None else self.count
         #text = getTextFromClipboard()
-        
+
         current_reg = self.register.GetSelectedRegister()
         text = self.register.GetCurrentRegister()
 
@@ -6904,14 +6904,14 @@ class ViHandler(ViHelper):
             self.ctrl.ReplaceSelection(text_to_paste)
         else:
             if is_line:
-                if not before:  
-                    # If pasting a line we have to goto the end before moving caret 
+                if not before:
+                    # If pasting a line we have to goto the end before moving caret
                     # down to handle long lines correctly
                     #self.ctrl.LineEnd()
                     self.MoveCaretDown(1)
                 self.GotoLineStart()
             else:
-                if not before:  
+                if not before:
                     self.MoveCaretRight(allow_last_char=True)
                     #line_text, pos = self.ctrl.GetCurLine()
                     #if len(line_text) != pos + 1:
@@ -6926,7 +6926,7 @@ class ViHandler(ViHelper):
             self.GotoLineIndent()
 
         self.EndUndo()
-                
+
     #--------------------------------------------------------------------
     # Deletion commands
     #--------------------------------------------------------------------
@@ -6964,7 +6964,7 @@ class ViHandler(ViHelper):
         self.StartSelection()
         self.MoveCaretRight(allow_last_char=True)
         self.SelectSelection(2)
-        
+
         ## If the selection len is less than the count we need to select
         ## the last character on the line
         #if len(self.ctrl.GetSelectedText()) < self.count:
@@ -7000,7 +7000,7 @@ class ViHandler(ViHelper):
         self.SelectCurrentLine()
         self.DeleteSelection()
         self.EndUndo()
-        
+
 
     #--------------------------------------------------------------------
     # Movement commands
@@ -7098,7 +7098,7 @@ class ViHandler(ViHelper):
 
         page_length = self.ctrl.GetLength()
 
-        text = self.ctrl.GetTextRaw()[:pos] 
+        text = self.ctrl.GetTextRaw()[:pos]
 
         n = -1
         for i in self.SENTENCE_ENDINGS:
@@ -7154,9 +7154,9 @@ class ViHandler(ViHelper):
             move_left = False
         else:
             include_whitespace = True
-            count = count / 2 
+            count = count / 2
             move_left = True
-        
+
         self.Repeat(self._MoveCaretNextSentence, count, include_whitespace)
 
         if move_left:
@@ -7164,7 +7164,7 @@ class ViHandler(ViHelper):
 
         #self.ctrl.CharLeftExtend()
 
-    def _MoveCaretNextSentence(self, include_whitespace=True, 
+    def _MoveCaretNextSentence(self, include_whitespace=True,
                                         pos=None, start_pos=None):
         # Could be combined with _MoveCaretBySentence func
         if pos is None:
@@ -7175,7 +7175,7 @@ class ViHandler(ViHelper):
 
         page_length = self.ctrl.GetLength()
 
-        text = self.ctrl.GetTextRaw()[pos:] 
+        text = self.ctrl.GetTextRaw()[pos:]
 
         n = page_length
         for i in self.SENTENCE_ENDINGS:
@@ -7214,7 +7214,7 @@ class ViHandler(ViHelper):
             else:
                 self.ctrl.GotoPos(sentence_end_pos)
         else:
-            self._MoveCaretNextSentence(include_whitespace, 
+            self._MoveCaretNextSentence(include_whitespace,
                                             sentence_end_pos, start_pos)
 
     def MoveCaretRight(self, allow_last_char=True):
@@ -7243,7 +7243,7 @@ class ViHandler(ViHelper):
         @param visual: If False ignore linewrap
         """
         if count is None: count = self.count
-        
+
         if visual:
             self.Repeat(self.ctrl.LineDown, count)
             self.CheckLineEnd()
@@ -7286,7 +7286,7 @@ class ViHandler(ViHelper):
         # Last line doesn't have an EOL char which the code below requires
         if self.OnLastLine():
             line = line + self.ctrl.GetEOLChar()
-            
+
         end_offset = 1
 
         if not allow_last_char and len(line) > 2:
@@ -7342,10 +7342,10 @@ class ViHandler(ViHelper):
 #            self.SetLineColumnPos()
 #
 #        return
-#               
+#
 #
 #        # The code below works but is slower than the above implementation (i think)
-#        
+#
 #        # TODO: Speedup
 #        line, line_pos = self.ctrl.GetCurLine()
 #        line_no = self.ctrl.GetCurrentLine()
@@ -7428,7 +7428,7 @@ class ViHandler(ViHelper):
 
 # word-motions
     def MoveCaretWordEndCountWhitespace(self, count=None):
-        self.Repeat(self._MoveCaretWord, count, 
+        self.Repeat(self._MoveCaretWord, count,
                         { "recursion" : False, "count_whitespace" : True, \
                                     "only_whitespace" : False })
 
@@ -7439,9 +7439,9 @@ class ViHandler(ViHelper):
 
     def MoveCaretPreviousWordEnd(self, count=None):
         # TODO: complete
-        self.Repeat(self._MoveCaretWord, count, { 
-                                    "recursion" : False, 
-                                    "count_whitespace" : False, 
+        self.Repeat(self._MoveCaretWord, count, {
+                                    "recursion" : False,
+                                    "count_whitespace" : False,
                                     "only_whitespace" : False,
                                     "reverse" : True
                                     })
@@ -7449,7 +7449,7 @@ class ViHandler(ViHelper):
     def MoveCaretWordEnd(self, count=None):
         self.Repeat(self._MoveCaretWord, count)
 
-    def _MoveCaretWord(self, recursion=False, count_whitespace=False, 
+    def _MoveCaretWord(self, recursion=False, count_whitespace=False,
                                         only_whitespace=False, reverse=False):
         """
         wxStyledTextCtrl's WordEnd function behaves differently to
@@ -7488,9 +7488,9 @@ class ViHandler(ViHelper):
             if not count_whitespace:
                 self.GotoPosAndSave(pos)
                 move()
-                self._MoveCaretWord(recursion=True, 
-                                   count_whitespace=count_whitespace, 
-                                   only_whitespace=only_whitespace, 
+                self._MoveCaretWord(recursion=True,
+                                   count_whitespace=count_whitespace,
+                                   only_whitespace=only_whitespace,
                                    reverse=reverse)
                 return
         # If we want a minor word end and start in punctuation we goto
@@ -7517,12 +7517,12 @@ class ViHandler(ViHelper):
         # We need to correct the position if using a unicode character
         if len(bytes(char)) > 2:
             pos = self.ctrl.PositionAfter(pos)
- 
+
         if pos != start_pos or recursion:
             self.GotoPosAndSave(pos)
         else:
             move_extend()
-            self._MoveCaretWord(True, count_whitespace=count_whitespace, 
+            self._MoveCaretWord(True, count_whitespace=count_whitespace,
                         only_whitespace=only_whitespace, reverse=reverse)
             return
 
@@ -7536,17 +7536,17 @@ class ViHandler(ViHelper):
         self.ctrl.GotoPos(start)
 
     def MoveCaretBackWord(self, count=None):
-        self.Repeat(self._MoveCaretWord, count, { 
-                                    "recursion" : False, 
-                                    "count_whitespace" : False, 
+        self.Repeat(self._MoveCaretWord, count, {
+                                    "recursion" : False,
+                                    "count_whitespace" : False,
                                     "only_whitespace" : False,
                                     "reverse" : True
                                     })
 
     def MoveCaretBackWORD(self, count=None):
-        self.Repeat(self._MoveCaretWord, count, { 
-                                    "recursion" : False, 
-                                    "count_whitespace" : False, 
+        self.Repeat(self._MoveCaretWord, count, {
+                                    "recursion" : False,
+                                    "count_whitespace" : False,
                                     "only_whitespace" : True,
                                     "reverse" : True
                                     })
@@ -7564,17 +7564,17 @@ class ViHandler(ViHelper):
         self.SetLineColumnPos()
 
     def MoveCaretWordEND(self, count=None):
-        self.Repeat(self._MoveCaretWord, count, { 
-                                    "recursion" : False, 
-                                    "count_whitespace" : False, 
-                                    "only_whitespace" : True 
+        self.Repeat(self._MoveCaretWord, count, {
+                                    "recursion" : False,
+                                    "count_whitespace" : False,
+                                    "only_whitespace" : True
                                     })
 
     def MoveCaretWordENDCountWhitespace(self, count=None):
-        self.Repeat(self._MoveCaretWord, count, { 
-                                    "recursion" : False, 
-                                    "count_whitespace" : True, 
-                                    "only_whitespace" : True 
+        self.Repeat(self._MoveCaretWord, count, {
+                                    "recursion" : False,
+                                    "count_whitespace" : True,
+                                    "only_whitespace" : True
                                     })
 
     def MoveCaretParaUp(self, count=None):
@@ -7615,7 +7615,7 @@ class ViHandler(ViHelper):
         k = self.KEY_BINDINGS
         if key in [k["G"], (k["g"], k["g"]), k["%"]]:
             self.AddJumpPosition()
-        
+
         # %, G or gg
         if self.true_count:
             if key in [k["G"], (k["g"], k["g"])]:
@@ -7638,13 +7638,13 @@ class ViHandler(ViHelper):
             self.ctrl.GotoLine(0)
 
         elif key == (k["G"]):
-            # As with vim "G" goes to the first nonwhitespace of the 
+            # As with vim "G" goes to the first nonwhitespace of the
             # character on the bottom line
             self.GotoLineIndent(self.ctrl.GetLineCount())
 
     def GotoViewportTop(self):
         self.GotoLineIndent(self.GetFirstVisibleLine())
-        
+
     def GotoViewportMiddle(self):
         self.GotoLineIndent(self.GetMiddleVisibleLine())
 
@@ -7665,7 +7665,7 @@ class ViHandler(ViHelper):
 
     def ScrollViewportUpFullScreen(self):
         # vim has a 2 line offset
-        # see *03.7* 
+        # see *03.7*
         self._ScrollViewport(-1)
 
     def ScrollViewportDownHalfScreen(self):
@@ -7680,7 +7680,7 @@ class ViHandler(ViHelper):
 #    def ScrollViewportLineUp(self):
 #        self._ScrollViewportByLines(-1)
 
-    # TODO: FIX UNDO / REDO 
+    # TODO: FIX UNDO / REDO
     def CanUndo(self):
         return not self._undo_pos < 0
 
@@ -7732,7 +7732,7 @@ class ViHandler(ViHelper):
         if indent is None:
             indent = self.ctrl.GetLineIndentation(self.ctrl.GetCurrentLine())
 
-        # This code is independent of the wikidpad syntax used 
+        # This code is independent of the wikidpad syntax used
         line_prefix = False
         line_text = self.ctrl.GetCurLine()[0].strip()
         if line_text.startswith(u"* "):
@@ -7749,7 +7749,7 @@ class ViHandler(ViHelper):
         self.ctrl.AddText(self.ctrl.GetEOLChar())
         if line_prefix:
             self.ctrl.AddText(line_prefix)
-            
+
         if create_first_line:
             self.MoveCaretUp(1)
         self.ctrl.SetLineIndentation(self.ctrl.GetCurrentLine(), indent)

--- a/lib/pwiki/WikiTxtDialogs.py
+++ b/lib/pwiki/WikiTxtDialogs.py
@@ -392,6 +392,13 @@ class ImagePasteSaver:
         return destPath
 
 
+    def isWmfInClipboard(self):
+        if WindowsHacks is None:
+            return None
+
+        return WindowsHacks.isWmfInClipboard()
+
+
     def saveWmfFromClipboardToFileStorage(self, fs):
         if WindowsHacks is None:
             return None

--- a/lib/pwiki/WikiTxtDialogs.py
+++ b/lib/pwiki/WikiTxtDialogs.py
@@ -31,10 +31,10 @@ except:
 
 
 class IncrementalSearchDialog(wx.Frame):
-    
+
     COLOR_YELLOW = wx.Colour(255, 255, 0);
     COLOR_GREEN = wx.Colour(0, 255, 0);
-    
+
     def __init__(self, parent, id, txtCtrl, rect, font, mainControl, searchInit=None):
         # Frame title is invisible but is helpful for workarounds with
         # third-party tools
@@ -194,7 +194,7 @@ class FilePasteParams:
         self.rawSuffix = u""  # Suffix after links
         self.bracketedUrl = True
 
-        self.unifActionName = None  # Unified name of the action to do 
+        self.unifActionName = None  # Unified name of the action to do
         self.defaultUnifActionName = None  # If action is ask, this is the default
                 # to show in dialog
 #         self.actionParamDict = None  # Parameter dict of action
@@ -222,7 +222,7 @@ class FilePasteParams:
 
 
 class FilePasteDialog(wx.Dialog, ModalDialogMixin):
-    
+
     _ACTIONSEL_TO_UNIFNAME = (
             u"action/editor/this/paste/files/insert/url/absolute",
             u"action/editor/this/paste/files/insert/url/relative",
@@ -230,7 +230,7 @@ class FilePasteDialog(wx.Dialog, ModalDialogMixin):
             u"action/editor/this/paste/files/insert/url/movetostorage"
         )
 
-    
+
     def __init__(self, pWiki, ID, filepastesaver, title=None,
                  pos=wx.DefaultPosition, size=wx.DefaultSize):
         d = wx.PreDialog()
@@ -249,7 +249,7 @@ class FilePasteDialog(wx.Dialog, ModalDialogMixin):
         self.ctrls.tfEditorFilePasteMiddle.SetValue(filepastesaver.rawMiddle)
         self.ctrls.tfEditorFilePasteSuffix.SetValue(filepastesaver.rawSuffix)
         self.ctrls.cbEditorFilePasteBracketedUrl.SetValue(filepastesaver.bracketedUrl)
-        
+
         try:
             self.ctrls.chEditorFilePasteOperation.SetSelection(
                     self._ACTIONSEL_TO_UNIFNAME.index(filepastesaver.defaultUnifActionName))
@@ -260,7 +260,7 @@ class FilePasteDialog(wx.Dialog, ModalDialogMixin):
 
         self.ctrls.btnOk.SetId(wx.ID_OK)
         self.ctrls.btnCancel.SetId(wx.ID_CANCEL)
-        
+
         # Fixes focus bug under Linux
         self.SetFocus()
 
@@ -297,7 +297,7 @@ class FilePasteDialog(wx.Dialog, ModalDialogMixin):
 
 class ImagePasteSaver:
     """
-    Helper class to store image settings (format, quality) and to 
+    Helper class to store image settings (format, quality) and to
     perform saving on request.
     """
     def __init__(self):
@@ -327,7 +327,7 @@ class ImagePasteSaver:
             quality = int(s)
             quality = min(100, quality)
             quality = max(0, quality)
-    
+
             self.quality = quality
         except ValueError:
             return
@@ -354,7 +354,7 @@ class ImagePasteSaver:
 
         img.SetOptionInt(u"quality", self.quality)
 
-        tempFileSet = TempFileSet() 
+        tempFileSet = TempFileSet()
 
         if self.formatNo == 1:   # PNG
             file_suffix = u".png"
@@ -395,7 +395,7 @@ class ImagePasteSaver:
     def saveWmfFromClipboardToFileStorage(self, fs):
         if WindowsHacks is None:
             return None
-        
+
         return WindowsHacks.saveWmfFromClipboardToFileStorage(fs, self.prefix)
 
 
@@ -407,7 +407,7 @@ class ImagePasteSaver:
         Returns absolute path of saved image or None if not saved
         """
         destPath = fs.findDestPathNoSource(u".wmf", self.prefix)
-        
+
         if destPath is None:
             # Couldn't find unused filename
             return None
@@ -417,7 +417,7 @@ class ImagePasteSaver:
         metaDC.Close()
 
 #         writeEntireFile(destPath, rawData)
-        
+
         return destPath
 
 
@@ -442,10 +442,10 @@ class ImagePasteDialog(wx.Dialog):
         self.ctrls.chEditorImagePasteFileType.SetSelection(imgpastesaver.formatNo)
         self.ctrls.tfEditorImagePasteQuality.SetValue(unicode(
                 imgpastesaver.quality))
-        
+
         self.origImage = img
         self.origImgWidth, self.origImgHeight = img.GetSize()
-        
+
         self.bitmapControl = wx.StaticBitmap(self.ctrls.pnImagePreviewContainer,
                 -1, wx.NullBitmap)
 
@@ -453,10 +453,10 @@ class ImagePasteDialog(wx.Dialog):
 
         self.ctrls.btnOk.SetId(wx.ID_OK)
         self.ctrls.btnCancel.SetId(wx.ID_CANCEL)
-        
+
         self.OnFileTypeChoice(None)
         self.OnSizePreviewBitmapContainer(None)
-        
+
         # Fixes focus bug under Linux
         self.SetFocus()
 
@@ -470,7 +470,7 @@ class ImagePasteDialog(wx.Dialog):
 
     def getImagePasteSaver(self):
         return self.imgpastesaver
-        
+
     def OnFileTypeChoice(self, evt):
         # Make quality field gray if not JPG format
         enabled = self.ctrls.chEditorImagePasteFileType.GetSelection() == 2
@@ -497,7 +497,7 @@ class ImagePasteDialog(wx.Dialog):
 
         newWidth, newHeight = Utilities.calcResizeArIntoBoundingBox(
                 self.origImgWidth, self.origImgHeight, bbWidth, bbHeight)
-                
+
         img_resize = self.origImage.Scale(newWidth, newHeight,
                 quality = wx.IMAGE_QUALITY_HIGH)
 
@@ -511,7 +511,7 @@ class RenameFileDialog(wx.Dialog):
     def __init__(self, parent, caption, title, filename):
         style = wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
         super(RenameFileDialog, self).__init__(parent, -1, title, style=style)
-        
+
         self.selectionSet = False
 
         text = wx.StaticText(self, -1, caption)
@@ -529,17 +529,17 @@ class RenameFileDialog(wx.Dialog):
 
         wx.EVT_SET_FOCUS(self.text_ctrl, self.OnFocus)
         self.text_ctrl.SetFocus()
-        
+
 
     def OnFocus(self, evt):
-        
+
         if self.selectionSet:
             return
 
         wx.CallAfter(self.RemoveExtensionFromSelection)
-        
+
         self.selectionSet = True
-        
+
 
     def RemoveExtensionFromSelection(self):
         # Remove selection from extension (if one exists)

--- a/lib/pwiki/WindowsHacks.py
+++ b/lib/pwiki/WindowsHacks.py
@@ -54,16 +54,16 @@ FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000
 
 SetClipboardViewer = _user32dll.SetClipboardViewer
 # HWND SetClipboardViewer(
-# 
-#     HWND hWndNewViewer 	// handle of clipboard viewer window  
+#
+#     HWND hWndNewViewer 	// handle of clipboard viewer window
 #    );
 
 
 ChangeClipboardChain = _user32dll.ChangeClipboardChain
 # BOOL ChangeClipboardChain(
-# 
-#     HWND hWndRemove,	// handle to window to remove  
-#     HWND hWndNewNext 	// handle to next window 
+#
+#     HWND hWndRemove,	// handle to window to remove
+#     HWND hWndNewNext 	// handle to next window
 #    );
 
 
@@ -77,7 +77,7 @@ OpenClipboard = _user32dll.OpenClipboard
 
 CloseClipboard = _user32dll.CloseClipboard
 # BOOL CloseClipboard(
-#     VOID 
+#     VOID
 #    );
 
 
@@ -134,7 +134,7 @@ DeleteMetaFile = _gdi32dll.DeleteMetaFile
 
 SendMessage = _user32dll.SendMessageA
 # SendMessage(
-# 
+#
 #     HWND hWnd,	// handle of destination window
 #     UINT Msg,	// message to send
 #     WPARAM wParam,	// first message parameter
@@ -146,7 +146,7 @@ SendMessage = _user32dll.SendMessageA
 
 SetWindowLong = _user32dll.SetWindowLongA
 # LONG SetWindowLong(
-# 
+#
 #     HWND hWnd,	// handle of window
 #     int nIndex,	// offset of value to set
 #     LONG dwNewLong 	// new value
@@ -172,7 +172,7 @@ GetLastError = _kernel32dll.GetLastError
 
 CallWindowProc = _user32dll.CallWindowProcA
 # LRESULT CallWindowProc(
-# 
+#
 #     WNDPROC lpPrevWndFunc,	// pointer to previous procedure
 #     HWND hWnd,	// handle to window
 #     UINT Msg,	// message
@@ -183,13 +183,13 @@ CallWindowProc = _user32dll.CallWindowProcA
 
 MultiByteToWideChar = _kernel32dll.MultiByteToWideChar
 # int MultiByteToWideChar(
-# 
-#     UINT CodePage,	// code page 
-#     DWORD dwFlags,	// character-type options 
-#     LPCSTR lpMultiByteStr,	// address of string to map 
-#     int cchMultiByte,	// number of characters in string 
-#     LPWSTR lpWideCharStr,	// address of wide-character buffer 
-#     int cchWideChar 	// size of buffer 
+#
+#     UINT CodePage,	// code page
+#     DWORD dwFlags,	// character-type options
+#     LPCSTR lpMultiByteStr,	// address of string to map
+#     int cchMultiByte,	// number of characters in string
+#     LPWSTR lpWideCharStr,	// address of wide-character buffer
+#     int cchWideChar 	// size of buffer
 #    );
 
 
@@ -210,7 +210,7 @@ VkKeyScan.argtypes = [ctypes.c_wchar]
 WindowProcType = ctypes.WINFUNCTYPE(ctypes.c_uint, ctypes.c_int, ctypes.c_uint,
         ctypes.c_uint, ctypes.c_ulong)
 # LRESULT CALLBACK WindowProc(
-# 
+#
 #     HWND hwnd,	// handle of window
 #     UINT uMsg,	// message identifier
 #     WPARAM wParam,	// first message parameter
@@ -227,15 +227,15 @@ except AttributeError:
     ShellExecuteW = None
 
 # HINSTANCE ShellExecute(
-# 
+#
 #     HWND hwnd,	// handle to parent window
 #     LPCTSTR lpOperation,	// pointer to string that specifies operation to perform
 #     LPCTSTR lpFile,	// pointer to filename or folder name string
-#     LPCTSTR lpParameters,	// pointer to string that specifies executable-file parameters 
+#     LPCTSTR lpParameters,	// pointer to string that specifies executable-file parameters
 #     LPCTSTR lpDirectory,	// pointer to string that specifies default directory
 #     INT nShowCmd 	// whether file is shown when opened
 #    );
-#    
+#
 
 
 
@@ -288,15 +288,15 @@ except AttributeError:
 if SHFileOperationW is not None:
     def _shellFileOp(opcode, srcPath, dstPath):
         fileOp = SHFILEOPSTRUCTW()
-        
+
         srcPathWc = ctypes.c_wchar_p(srcPath + u"\0")
-    
+
         fileOp.hwnd = 0
         fileOp.wFunc = opcode
         fileOp.pFrom = srcPathWc
         if dstPath is not None:
             dstDir = os.path.dirname(dstPath)
-                
+
             if not os.path.exists(pathEnc(dstDir)):
                 os.makedirs(dstDir)
 
@@ -335,17 +335,17 @@ if SHFileOperationW is not None:
         Copy file from srcPath to dstPath. dstPath may be overwritten if
         existing already. dstPath must point to a file, not a directory.
         If some directories in dstPath do not exist, they are created.
-        
+
         This function only works on Win NT!
         """
         _shellFileOp(FO_COPY, srcPath, dstPath)
-    
+
     def moveFile(srcPath, dstPath):
         """
         Move file from srcPath to dstPath. dstPath may be overwritten if
         existing already. dstPath must point to a file, not a directory.
         If some directories in dstPath do not exist, they are created.
-        
+
         This function only works on Win NT!
         """
         _shellFileOp(FO_MOVE, srcPath, dstPath)
@@ -353,7 +353,7 @@ if SHFileOperationW is not None:
     def deleteFile(path):
         """
         Delete file or directory  path.
-        
+
         This function only works on Win NT!
         """
         if os.path.isfile(path) or os.path.islink(path):
@@ -371,7 +371,7 @@ def _getMemoryContentFromHandle(hdl):
         return None
     try:
         size = GlobalSize(hdl)
-        
+
         return string_at(pt, size)
     finally:
         GlobalUnlock(hdl)
@@ -381,28 +381,28 @@ def saveWmfFromClipboardToFileStorage(fs, prefix):
     """
     Retrieve raw Windows meta data file from clipboard. Return None,
     if not present.
-    
+
     fs -- FileStorage to save to
-    
+
     Returns path to new file or None.
     """
     OpenClipboard(0)
     try:
         if IsClipboardFormatAvailable(CF_METAFILEPICT) == 0:
             return None
-        
+
         hdl = GetClipboardData(CF_METAFILEPICT)
         if hdl == 0:
             return None
-        
+
         data = _getMemoryContentFromHandle(hdl)
         if data is None:
             return None
-        
+
         hdl = struct.unpack("lllI", data)[3]
-        
+
         destPath = fs.findDestPathNoSource(u".wmf", prefix)
-        
+
         if destPath is None:
             # Couldn't find unused filename
             return None
@@ -432,7 +432,7 @@ GetLongPathName = _kernel32dll.GetLongPathNameW
 def getLongPath(path):
     if isinstance(path, str):
         path = mbcsDec(path)[0]
-    
+
     if not isinstance(path, unicode):
         return path
 
@@ -447,7 +447,7 @@ def getLongPath(path):
     if rv > 1024:
         result = create_unicode_buffer(rv)
         rv = GetLongPathName(u"\\\\?\\" + path, result, rv)
-        
+
         if rv == 0:
             return path
 
@@ -459,7 +459,7 @@ def getErrorMessageFromCode(errCode):
 
     FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ARGUMENT_ARRAY,
             0, errCode, 0, result, 1024, 0)
-    
+
     return result.value
 
 
@@ -484,7 +484,7 @@ def ansiInputToUnicodeChar(ansiCode):
 
     # get current locale
     lcid = _user32dll.GetKeyboardLayout(0) & 0xffff
-    
+
     # get codepage for locale
     currAcpStr = (c_char * 50)()
 
@@ -495,13 +495,13 @@ def ansiInputToUnicodeChar(ansiCode):
         codepage = int(currAcpStr.value)
     except:
         return unichr(ansiCode)
-        
+
     ansiByte = c_byte(ansiCode)
     uniChar = (c_ushort * 2)()
-    
+
     length = MultiByteToWideChar(codepage, MB_PRECOMPOSED, byref(ansiByte), 1,
             byref(uniChar), 2)
-            
+
     if length == 0:
         # function failed, fallback
         return unichr(ansiCode)
@@ -521,7 +521,7 @@ if ShellExecuteW:
         # TODO Test result?
         res = _shell32dll.ShellExecuteW(0, 0, ctypes.c_wchar_p(link), 0, 0,
                 SW_SHOW)
-                
+
         return res
 
 
@@ -550,7 +550,7 @@ def translateAcceleratorByKbLayout(accStr):
         # Build mapping
 
         result = {}
-        
+
         # Dictionary for alternative detection method
         resultBack = {}
 
@@ -584,7 +584,7 @@ def translateAcceleratorByKbLayout(accStr):
                 continue
 
             result[targetChar] = unichr(char)
-            
+
         # If result and resultBack have a key, result wins
         resultBack.update(result)
         _ACCEL_KEY_MAPPING = resultBack
@@ -607,12 +607,12 @@ class WinProcParams:
         self.wParam = wParam
         self.lParam = lParam
         self.returnValue = None
-        
+
 
 class BaseWinInterceptor:
     def __init__(self):
         pass
-        
+
     def addInterceptCollection(self, interceptCollection):
         """
         Called automatically if interceptor is added to an
@@ -651,7 +651,7 @@ class BaseWinInterceptor:
         uninterception doesn't happen (this may be dangerous).
         """
         return True
-        
+
     def stopAfterUnintercept(self, interceptCollection):
         """
         Called for each interceptor of a collection after the actual
@@ -664,7 +664,7 @@ class BaseWinInterceptor:
         """
         Called for each Windows message to the intercepted window. This is
         the ANSI-style method, wide-char is not supported.
-        
+
         params -- WinProcParams object containing parameters the function can
                 modify and a returnValue which can be set to prevent
                 from calling interceptWinProc functions
@@ -686,9 +686,9 @@ class WinProcInterceptCollection:
         self.ctWinProcStub = None
         self.hWnd = None
         self.interceptors = []
-        
+
         self.winParams = WinProcParams()
-        
+
         if interceptors is not None:
             for icept in interceptors:
                 self.addInterceptor(icept)
@@ -708,10 +708,10 @@ class WinProcInterceptCollection:
 
         for icept in self.interceptors:
             icept.removeInterceptCollection(self)
-        
+
         self.interceptors = []
-    
-    
+
+
     def close(self):
         self.clear()
 
@@ -723,11 +723,11 @@ class WinProcInterceptCollection:
     def start(self, callingWindow):
         if self.isIntercepting():
             return False
-            
+
         for icept in self.interceptors:
             if not icept.startBeforeIntercept(self):
                 return False
-        
+
         self.intercept(callingWindow)
 
         for icept in self.interceptors:
@@ -735,23 +735,23 @@ class WinProcInterceptCollection:
                 icept.startAfterIntercept(self)
             except:
                 traceback.print_exc()
-                
+
         return True
 
 
     def stop(self):
         if not self.isIntercepting():
             return False
-            
+
         for icept in self.interceptors:
             try:
                 if not icept.stopBeforeUnintercept(self):
                     return False
             except:
                 traceback.print_exc()
-        
+
         self.unintercept()
-        
+
         for icept in self.interceptors:
             try:
                 icept.stopAfterUnintercept(self)
@@ -776,7 +776,7 @@ class WinProcInterceptCollection:
     def unintercept(self):
         if not self.isIntercepting():
             return
-            
+
         SetWindowLong(c_int(self.hWnd), c_int(GWL_WNDPROC),
                 c_int(self.oldWndProc))
 
@@ -787,14 +787,14 @@ class WinProcInterceptCollection:
 
     def isIntercepting(self):
         return self.hWnd is not None
-        
+
 
     def _lastWinProc(self, params):
         """
         This default function reacts only on a WM_DESTROY message and
         stops interception. All messages are sent to the original WinProc
         """
-        
+
         if params.uMsg == WM_DESTROY and params.hWnd == self.hWnd:
             self.stop()
 
@@ -812,14 +812,14 @@ class WinProcInterceptCollection:
                 icept.interceptWinProc(self, params)
             except:
                 traceback.print_exc()
-            
+
             if params.returnValue is not None:
                 return params.returnValue
-        
+
         self._lastWinProc(params)
         return params.returnValue
 
-        
+
 
 
 
@@ -829,7 +829,7 @@ class WinProcInterceptCollection:
 #     """
 #     def winProc(self, hWnd, uMsg, wParam, lParam):
 #         print "Intercept1", repr((uMsg, wParam, lParam))
-#         
+#
 #         return BaseWinProcIntercept.winProc(self, hWnd, uMsg, wParam, lParam)
 
 
@@ -840,10 +840,10 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
     MODE_OFF = 0
     MODE_AT_PAGE = 1
     MODE_AT_CURSOR = 2
-    
+
     def __init__(self, mainControl):
         BaseWinInterceptor.__init__(self)
-        
+
         self.hWnd = None
         self.nextWnd = None
 
@@ -857,7 +857,7 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
 
     def getMode(self):
         return self.mode
-        
+
     def _cbViewerChainIn(self):
         """
         Hook into clipboard viewer chain.
@@ -891,7 +891,7 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
             self.mainControl.displayErrorMessage(
                     _(u"Only a real wiki page can be a clipboard catcher"))
             return
-            
+
         self.lastText = None
         self.wikiPage = wikiPage
         self.mode = ClipboardCatchIceptor.MODE_AT_PAGE
@@ -921,7 +921,7 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
         if self.mode == ClipboardCatchIceptor.MODE_AT_CURSOR:
             self.ignoreNextCCMessage = True
             self.lastText = None
-    
+
     def informCopyInWikidPadStop(self):
         pass
 
@@ -947,7 +947,7 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
         """
         Called for each Windows message to the intercepted window. This is
         the ANSI-style method, wide-char is not supported.
-        
+
         params -- WinProcParams object containing parameters the function can
                 modify and a returnValue which can be set to prevent
                 from calling interceptWinProc functions
@@ -956,7 +956,7 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
             if self.nextWnd == params.wParam:
                 # repair the chain
                 self.nextWnd = params.lParam
-    
+
             if self.nextWnd:  # Neither None nor 0
                 # pass the message to the next window in chain
                 SendMessage(c_int(self.nextWnd), c_int(params.uMsg),
@@ -1015,7 +1015,7 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
 
         if self.mode == ClipboardCatchIceptor.MODE_OFF:
             return
-            
+
         if self.mainControl.getConfig().getboolean("main",
                 "clipboardCatcher_filterDouble", True) and self.lastText == text:
             # Same text shall be inserted again
@@ -1026,11 +1026,11 @@ class ClipboardCatchIceptor(BaseWinInterceptor):
                 return
             self.wikiPage.appendLiveText(prefix + text + suffix)
             self.notifyUserOnClipboardChange()
-            
+
         elif self.mode == ClipboardCatchIceptor.MODE_AT_CURSOR:
             self.mainControl.getActiveEditor().ReplaceSelection(prefix + text + suffix)
             self.notifyUserOnClipboardChange()
-            
+
         self.lastText = text
 
 
@@ -1052,7 +1052,7 @@ class BrowserMoveIceptor(BaseWinInterceptor):
     """
     def __init__(self, mainControl):
         BaseWinInterceptor.__init__(self)
-        
+
         self.mainControl = mainControl
 
 
@@ -1062,8 +1062,8 @@ class BrowserMoveIceptor(BaseWinInterceptor):
 #         intercept happened.
 #         """
 #         self.hWnd = interceptCollection.getHWnd()
-# 
-# 
+#
+#
 #     def stopAfterUnintercept(self, interceptCollection):
 #         """
 #         Called for each interceptor of a collection after the actual
@@ -1077,7 +1077,7 @@ class BrowserMoveIceptor(BaseWinInterceptor):
         """
         Called for each Windows message to the intercepted window. This is
         the ANSI-style method, wide-char is not supported.
-        
+
         params -- WinProcParams object containing parameters the function can
                 modify and a returnValue which can be set to prevent
                 from calling interceptWinProc functions

--- a/lib/pwiki/WindowsHacks.py
+++ b/lib/pwiki/WindowsHacks.py
@@ -377,6 +377,30 @@ def _getMemoryContentFromHandle(hdl):
         GlobalUnlock(hdl)
 
 
+def isWmfInClipboard():
+    """
+    Check whether there is raw Windows meta data file in current clipboard.
+    Return True/False.
+    """
+    OpenClipboard(0)
+    try:
+        if IsClipboardFormatAvailable(CF_METAFILEPICT) == 0:
+            return False
+
+        hdl = GetClipboardData(CF_METAFILEPICT)
+        if hdl == 0:
+            return False
+
+        data = _getMemoryContentFromHandle(hdl)
+        if data is None:
+            return False
+
+    finally:
+        CloseClipboard()
+
+    return True
+
+
 def saveWmfFromClipboardToFileStorage(fs, prefix):
     """
     Retrieve raw Windows meta data file from clipboard. Return None,


### PR DESCRIPTION
With the new options it can be set up to "paste text instead of image" always or for WMF files.

Note:  Here there are many lines with removed trailing whitespace too.
